### PR TITLE
Feature/core publishing

### DIFF
--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -1,8 +1,9 @@
 plugins {
     kotlin("multiplatform")
+    `maven-publish`
 }
 
-group = "com.rootstrap.flowforms.core"
+group = "com.github.rootstrap"
 version = "0.0.1-SNAPSHOT"
 
 kotlin {

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     `maven-publish`
 }
 
-group = "com.github.rootstrap"
+group = "com.rootstrap"
 version = "0.0.1-SNAPSHOT"
 
 kotlin {

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
 }
 
 group = "com.rootstrap"
-version = "0.0.1-SNAPSHOT"
+version = "0.0.1"
 
 kotlin {
     jvm {

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FForm.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FForm.kt
@@ -31,7 +31,7 @@ open class FForm {
      * its fields begin to change their inner status. It becomes [CORRECT] when
      * all the fields status are [CORRECT].
      *
-     * If only one field is [INCORRECT] then the form status becomes [FormStatus.Incorrect] event if
+     * If only one field is [INCORRECT] then the form status becomes [FormStatus.Incorrect] even if
      * the other fields are [UNMODIFIED]
      */
     @OptIn(ExperimentalCoroutinesApi::class)

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FormTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FormTest.kt
@@ -173,7 +173,7 @@ class FormTest {
     }
 
     @Test
-    fun `GIVEN a form with 3 fields WHEN from they become correct at different times THEN assert the form status changes from UNMODIFIED to INCOMPLETE x2 to INCORRECT`()
+    fun `GIVEN a form with 3 fields WHEN from they become correct at different times THEN assert the form status changes from UNMODIFIED to INCOMPLETE x2 to CORRECT`()
             = runTest {
         val form = FForm()
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ allprojects {
 }
 ```
 
-- Add FlowForms dependency :
+- Add FlowForms dependency in you module's build.gradle file :
 ```kotlin
 dependencies {
   ..

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ allprojects {
 ```
 dependencies {
   ...
-  implementation("com.github.rootstrap:FlowForms:feature~core-publishing-SNAPSHOT")
+  implementation("com.github.rootstrap:FlowForms:0.0.1")
   ...
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,25 +19,34 @@ KMP library for form management
 
 ## Installation (using gradle)
 - Add the JitPack repository to your root build.gradle file, at the end of repositories :
-```
+```kotlin
 allprojects {
   repositories {
-    ...
+    ..
     maven { url 'https://jitpack.io' }
   }
 }
 ```
 
 - Add FlowForms dependency :
-```
+```kotlin
 dependencies {
-  ...
-  implementation("com.github.rootstrap:FlowForms:0.0.1")
-  ...
+  ..
+  var flowFormsVersion = "v0.0.1"
+
+  // Use this to get FlowForms Core module only for jvm targets
+  implementation("com.github.rootstrap.FlowForms:FlowForms-Core-jvm:$flowFormsVersion")
+
+  // Use this to get the whole FlowForms Core module (for all available targets)
+  implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")
+  
+  // Use this to get every FlowForms modules together (currently we only have FlowForms Core so it's the same as above) 
+  implementation("com.github.rootstrap:FlowForms:$flowFormsVersion")
+  ..
 }
 ```
 
-- Only FlowForms Core is available at the moment. It's a kotlin only library so you can use it whenever you use Kotlin.
+- Only FlowForms Core is available at the moment. It's a kotlin only library so you can use FlowForms-Core dependency whenever you use Kotlin.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # FlowForms
 
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![](https://jitpack.io/v/rootstrap/FlowForms.svg)](https://jitpack.io/#rootstrap/FlowForms) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+
 
 WIP badges :
 - ![Build Status](https://github.com/rootstrap/FlowForms/workflows/CI/badge.svg)
@@ -16,14 +17,27 @@ KMP library for form management
 
 ---
 
-## Prerequisites
-- At the moment, the project can only be ran inside Android Studio due to Intellij's lack of support for the Android Gradle Plugin (AGP) 7.+. A GIT issue will be created to reduce the AGP version to the latest supported by the IntelliJ IDEA IDE. As MPP projects are intended to be ran using Intellij IDEA.
-- WIP 🚧
+## Installation (using gradle)
+- Add the JitPack repository to your root build.gradle file, at the end of repositories :
+```
+allprojects {
+  repositories {
+    ...
+    maven { url 'https://jitpack.io' }
+  }
+}
+```
 
----
+- Add FlowForms dependency :
+```
+dependencies {
+  ...
+  implementation("com.github.rootstrap:FlowForms:feature~core-publishing-SNAPSHOT")
+  ...
+}
+```
 
-## Installation
-- WIP 🚧
+- Only FlowForms Core is available at the moment. It's a kotlin only library so you can use it whenever you use Kotlin.
 
 ---
 
@@ -36,6 +50,9 @@ KMP library for form management
 Bug reports (please use Issues) and pull requests are welcome on GitHub at https://github.com/rootstrap/FlowForms. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [Contributor Covenant](http://contributor-covenant.org) code of conduct.
 
 For more information check the [official notion page](https://www.notion.so/rootstrap/FlowForms-KMP-library-for-form-management-starting-with-Android-43ee69a08a17450a89cf8db695ec1bd9), where you can see the project's goals, architecture and desired usability.
+
+### Prerequisites
+- At the moment, the project can only be ran inside Android Studio due to Intellij's lack of support for the Android Gradle Plugin (AGP) 7.+. A GIT issue will be created to reduce the AGP version to the latest supported by the IntelliJ IDEA IDE. As MPP projects are intended to be ran using Intellij IDEA.
 
 ### Unit testing
 


### PR DESCRIPTION
#### Description
 * Setup project to upload artifacts under com.rootstrap group
 * Made the first release using Jitpack! 0.0.1 - https://jitpack.io/#rootstrap/FlowForms
 * Used the release in an external project to add documentation on how to import it as a dependency in any kotlin project with Gradle.
 * Fix typo in FForm's Kdoc.
 * Move pre-requisites section inside the Contribution sector, as those pre-requisites are only for contributing to the project, not for using it.
 * Added jitpack last release badge to the README.
 * Part of #10 


#### Screenshots 
<img width="404" alt="image" src="https://user-images.githubusercontent.com/26490822/172189424-cb278682-4e9a-479a-bcc1-8c7c1f37580a.png">
