### PR TITLE
Async validation support. Code coverage plugin

### DIFF
--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     kotlin("multiplatform")
+    id("org.jetbrains.kotlinx.kover") version "0.5.1"
     `maven-publish`
 }
 

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -31,6 +31,12 @@ kotlin {
     }
 }
 
+val rootPkg = "com.rootstrap.flowforms"
+
+tasks.koverMergedHtmlReport {
+    excludes = listOf("${rootPkg}.core.common.StatusCodes","${rootPkg}.util.*")
+}
+
 // utility functions
 
 fun org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler.implementations(list : List<String>) {

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/common/StatusCodes.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/common/StatusCodes.kt
@@ -16,6 +16,11 @@ object StatusCodes {
     const val CORRECT = "correct"
 
     /**
+     * Status for fields whose async validations didn't finished yet
+     */
+    const val IN_PROGRESS = "in_progress"
+
+    /**
      * Status for a form not validated at all. This can happen when some fields are Correct
      * and others are unmodified.
      *

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldStatus.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldStatus.kt
@@ -2,6 +2,7 @@ package com.rootstrap.flowforms.core.field
 
 import com.rootstrap.flowforms.core.common.StatusCodes.CORRECT
 import com.rootstrap.flowforms.core.common.StatusCodes.INCORRECT
+import com.rootstrap.flowforms.core.common.StatusCodes.IN_PROGRESS
 import com.rootstrap.flowforms.core.common.StatusCodes.UNMODIFIED
 import com.rootstrap.flowforms.core.validation.ValidationResult
 
@@ -10,7 +11,7 @@ import com.rootstrap.flowforms.core.validation.ValidationResult
  *
  * By default every fieldStatus starts at [UNMODIFIED]
  *
- * @property code The status of the field. Being it [UNMODIFIED], [CORRECT], [INCORRECT] or a custom error code
+ * @property code The status of the field. Being it [UNMODIFIED], [CORRECT], [INCORRECT], [IN_PROGRESS] or a custom error code
  * @property validationResults : the list of validations with their results, triggered to reach this status.
  */
 data class FieldStatus(

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Required.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Required.kt
@@ -14,7 +14,7 @@ import com.rootstrap.flowforms.core.common.StatusCodes.REQUIRED_UNSATISFIED
  */
 class Required(val valueProvider : () -> String?) : Validation() {
 
-    override fun validate() = ValidationResult(
+    override suspend fun validate() = ValidationResult(
         if (valueProvider().isNullOrEmpty())
             REQUIRED_UNSATISFIED
         else

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
@@ -8,7 +8,9 @@ import com.rootstrap.flowforms.core.common.StatusCodes.INCORRECT
  *
  * **Properties :**
  *  * failFast : Determines if this validation should short-circuit the validation process.
+ * Defaults to true.
  * * async : Determines if the validation should be triggered asynchronously.
+ * Defaults to false.
  */
 abstract class Validation(val failFast : Boolean = true, val async : Boolean = false) {
 

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
@@ -17,7 +17,7 @@ abstract class Validation(val failFast : Boolean = true, val async : Boolean = f
     /**
      * Represents a validation that must return a result when invoked.
      */
-    abstract fun validate() : ValidationResult
+    abstract suspend fun validate() : ValidationResult
 }
 
 /**
@@ -36,5 +36,10 @@ data class ValidationResult(
          * empty ValidationResult with [CORRECT] status code
          */
         val Correct = ValidationResult(CORRECT)
+
+        /**
+         * empty ValidationResult with [INCORRECT] status code
+         */
+        val Incorrect = ValidationResult(INCORRECT)
     }
 }

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/validation/Validation.kt
@@ -6,10 +6,11 @@ import com.rootstrap.flowforms.core.common.StatusCodes.INCORRECT
 /**
  * Used by [FField] to update their status given the sum of the validationResults
  *
- * @property failFast : if true it short-circuits the validation process of the field with the
- * [ValidationResult] returned by the [validate] call as it's current status **if it's not [CORRECT]**
+ * **Properties :**
+ *  * failFast : Determines if this validation should short-circuit the validation process.
+ * * async : Determines if the validation should be triggered asynchronously.
  */
-abstract class Validation(val failFast : Boolean = true) {
+abstract class Validation(val failFast : Boolean = true, val async : Boolean = false) {
 
     /**
      * Represents a validation that must return a result when invoked.

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/util/Extensions.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/util/Extensions.kt
@@ -1,0 +1,10 @@
+package com.rootstrap.flowforms.util
+
+/**
+ * Executes the given function when the list is not empty sending itself as a parameter
+ */
+inline fun <E> Collection<E>.whenNotEmpty(block : Collection<E>.() -> Unit ) {
+    if (this.isNotEmpty()) {
+        block()
+    }
+}

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/util/Extensions.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/util/Extensions.kt
@@ -1,10 +1,11 @@
 package com.rootstrap.flowforms.util
 
 /**
- * Executes the given function when the list is not empty sending itself as a parameter
+ * Executes the given function when the collection is not empty and the given condition
+ * is met, using the collection as the scope
  */
-inline fun <E> Collection<E>.whenNotEmpty(block : Collection<E>.() -> Unit ) {
-    if (this.isNotEmpty()) {
+inline fun <E> Collection<E>.whenNotEmptyAnd(condition : () -> Boolean, block : Collection<E>.() -> Unit ) {
+    if (this.isNotEmpty() && condition()) {
         block()
     }
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/TriggerValidationsTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/TriggerValidationsTest.kt
@@ -22,6 +22,7 @@ class TriggerValidationsTest {
         val correctValidation = mockk<Validation>()
 
         every { correctValidation.validate() } returns ValidationResult.Correct
+        every { correctValidation.async } returns false
 
         val field = FField("email", listOf( correctValidation ) )
 
@@ -40,6 +41,7 @@ class TriggerValidationsTest {
 
         every { failingValidation.validate() } returns ValidationResult(INCORRECT)
         every { failingValidation.failFast } returns false
+        every { failingValidation.async } returns false
 
         val field = FField("email", listOf( failingValidation ) )
 
@@ -59,8 +61,10 @@ class TriggerValidationsTest {
 
         every { correctValidation.validate() } returns ValidationResult.Correct
         every { correctValidation.failFast } returns false
+        every { correctValidation.async } returns false
         every { failingValidation.validate() } returns ValidationResult(INCORRECT)
         every { failingValidation.failFast } returns false
+        every { failingValidation.async } returns false
 
         val field = FField("email", listOf( correctValidation, failingValidation ) )
 
@@ -80,8 +84,10 @@ class TriggerValidationsTest {
 
         every { failingValidation.validate() } returns ValidationResult(INCORRECT)
         every { failingValidation.failFast } returns false
+        every { failingValidation.async } returns false
         every { correctValidation.validate() } returns ValidationResult.Correct
         every { correctValidation.failFast } returns false
+        every { correctValidation.async } returns false
 
         val field = FField("email", listOf( failingValidation, correctValidation ) )
 
@@ -101,8 +107,10 @@ class TriggerValidationsTest {
 
         every { failingValidation.validate() } returns ValidationResult(INCORRECT)
         every { failingValidation.failFast } returns true
+        every { failingValidation.async } returns false
         every { correctValidation.validate() } returns ValidationResult(CORRECT)
         every { correctValidation.failFast } returns true
+        every { correctValidation.async } returns false
 
         val field = FField("email", listOf( failingValidation, correctValidation ) )
 

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/TriggerValidationsTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/TriggerValidationsTest.kt
@@ -1,5 +1,6 @@
 package com.rootstrap.flowforms.core.field
 
+import app.cash.turbine.FlowTurbine
 import app.cash.turbine.test
 import com.rootstrap.flowforms.core.common.StatusCodes.CORRECT
 import com.rootstrap.flowforms.core.common.StatusCodes.INCORRECT
@@ -24,7 +25,7 @@ import kotlin.test.assertIs
 class TriggerValidationsTest {
 
     @Test
-    fun `GIVEN a correct validation THEN assert the field status is CORRECT`()
+    fun `GIVEN a validation WHEN it is correct THEN assert the field status is CORRECT`()
     = runTest {
         val correctValidation = validation(ValidationResult.Correct)
         val field = FField("email", listOf(correctValidation))
@@ -32,36 +33,38 @@ class TriggerValidationsTest {
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerValidations()
-            assertEquals(awaitItem().code, CORRECT)
+            assertEquals(CORRECT, awaitItem().code)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `GIVEN a failing validation THEN assert the field status is INCORRECT`()
+    fun `GIVEN a validation with a custom error code WHEN it fails THEN assert the field status is the custom error code`()
     = runTest {
-        val failingValidation = validation(ValidationResult.Incorrect)
+        val customErrorCode = "custom-code"
+        val failingValidation = validation(ValidationResult(customErrorCode))
         val field = FField("email", listOf( failingValidation ) )
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerValidations()
-            assertEquals(awaitItem().code, INCORRECT)
+            assertEquals(customErrorCode, awaitItem().code)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `GIVEN a correct and a failing validations THEN assert the field status is INCORRECT`()
+    fun `GIVEN two validations WHEN one is correct and the other is incorrect but with a custom error code THEN assert the field status is that errorCode`()
     = runTest {
+        val customErrorCode = "Custom-code"
         val correctValidation = validation(ValidationResult.Correct)
-        val failingValidation = validation(ValidationResult.Incorrect)
+        val failingValidation = validation(ValidationResult(customErrorCode))
         val field = FField("email", listOf(correctValidation, failingValidation))
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerValidations()
-            assertEquals(awaitItem().code, INCORRECT)
+            assertEquals(customErrorCode, awaitItem().code)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -76,7 +79,7 @@ class TriggerValidationsTest {
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerValidations()
-            assertEquals(awaitItem().code, INCORRECT)
+            assertEquals(INCORRECT, awaitItem().code)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -118,52 +121,44 @@ class TriggerValidationsTest {
 
         field.status.test {
             field.triggerValidations(testAsyncCoroutineDispatcher)
-
-            assertEquals(awaitItem().code, UNMODIFIED)
-            assertEquals(awaitItem().code, IN_PROGRESS)
-            assertEquals(awaitItem().code, CORRECT)
+            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, CORRECT)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
     fun `GIVEN a incorrect async validation THEN assert the field status CHANGES from unmodified to in progress to Incorrect`()
-            = runTest {
+    = runTest {
         val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
         val incorrectAsyncValidation = asyncValidation(0, ValidationResult.Incorrect)
         val field = FField("email", listOf(incorrectAsyncValidation))
 
         field.status.test {
             field.triggerValidations(testAsyncCoroutineDispatcher)
-
-            assertEquals(awaitItem().code, UNMODIFIED)
-            assertEquals(awaitItem().code, IN_PROGRESS)
-            assertEquals(awaitItem().code, INCORRECT)
+            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
-    fun `GIVEN a correct and then an incorrect async validations THEN assert the field status CHANGES from unmodified to in progress to Incorrect`()
-            = runTest {
+    fun `GIVEN two async validations WHEN the first is correct but the second is incorrect with a custom error code THEN assert the field status CHANGES from unmodified to in progress to that custom error code`()
+    = runTest {
+        val customErrorCode = "custom-code"
         val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
         val correctAsyncValidation = asyncValidation(0, ValidationResult.Correct)
-        val incorrectAsyncValidation = asyncValidation(0, ValidationResult.Incorrect)
+        val incorrectAsyncValidation = asyncValidation(0, ValidationResult(customErrorCode))
         val field = FField("email", listOf(correctAsyncValidation, incorrectAsyncValidation))
 
         field.status.test {
             field.triggerValidations(testAsyncCoroutineDispatcher)
-
-            assertEquals(awaitItem().code, UNMODIFIED)
-            assertEquals(awaitItem().code, IN_PROGRESS)
-            assertEquals(awaitItem().code, INCORRECT)
+            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, customErrorCode)
             cancelAndIgnoreRemainingEvents()
         }
     }
 
     @Test
     fun `GIVEN 3 async validations with different duration WHEN the middle one is failFast and fails THEN assert the last one was cancelled`()
-            = runTest {
+    = runTest {
         val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
         val fastestVal = asyncValidation(10, ValidationResult.Correct)
         val middleIncorrectVal = asyncValidation(20, ValidationResult.Incorrect, true)
@@ -173,16 +168,81 @@ class TriggerValidationsTest {
         field.status.test {
             field.triggerValidations(testAsyncCoroutineDispatcher)
 
-            assertEquals(awaitItem().code, UNMODIFIED)
-            assertEquals(awaitItem().code, IN_PROGRESS)
-            val lastStatus = awaitItem()
-            assertEquals(lastStatus.code, INCORRECT)
+            val lastStatus = assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
             // checks that the slower validation was not added to the results (because it was cancelled before)
             assertEquals(2, lastStatus.validationResults.size)
             cancelAndIgnoreRemainingEvents()
         }
 
     }
+
+    @Test
+    fun `GIVEN 1 sync and 1 async validation WHEN both are correct THEN assert both was executed and the field status changes from UNMODIFIED to INPROGRESS to CORRECT`()
+    = runTest {
+        val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
+        val regularValidation = validation(ValidationResult.Correct)
+        val asyncValidation = asyncValidation(10, ValidationResult.Correct)
+        val field = FField("email", listOf(regularValidation, asyncValidation))
+
+        field.status.test {
+            field.triggerValidations(testAsyncCoroutineDispatcher)
+            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, CORRECT)
+
+            coVerify(exactly = 1) { regularValidation.validate() }
+            coVerify(exactly = 1) { asyncValidation.validate() }
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN 1 failFast sync and 1 async validation WHEN the sync validation fails THEN assert the async validation was not executed and the field status changes from UNMODIFIED to INCORRECT`()
+    = runTest {
+        val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
+        val regularValidation = validation(ValidationResult.Incorrect, true)
+        val asyncValidation = asyncValidation(10, ValidationResult.Correct)
+        val field = FField("email", listOf(regularValidation, asyncValidation))
+
+        field.status.test {
+            field.triggerValidations(testAsyncCoroutineDispatcher)
+            assertFieldStatusSequence(this, UNMODIFIED, INCORRECT)
+
+            coVerify(exactly = 1) { regularValidation.validate() }
+            coVerify(exactly = 0) { asyncValidation.validate() }
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN 2 async validations with custom error codes WHEN both fails THEN assert the field status changes from UNMODIFIED to IN_PROGRESS to INCORRECT and the validation results contains the custom error codes`()
+    = runTest {
+        val customErrorCode1 = "custom-error-code-1"
+        val customErrorCode2 = "custom-error-code-2"
+        val testAsyncCoroutineDispatcher = StandardTestDispatcher(testScheduler, name = "IO dispatcher")
+        val asyncValidation = asyncValidation(5, ValidationResult(customErrorCode1))
+        val asyncValidation2 = asyncValidation(5, ValidationResult(customErrorCode2))
+        val field = FField("email", listOf(asyncValidation, asyncValidation2))
+
+        field.status.test {
+            field.triggerValidations(testAsyncCoroutineDispatcher)
+            val lastStatusResults = assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
+                .validationResults
+
+            coVerify(exactly = 1) { asyncValidation.validate() }
+            coVerify(exactly = 1) { asyncValidation2.validate() }
+
+            assertEquals(2, lastStatusResults.filter {
+                it.resultId == customErrorCode1 || it.resultId == customErrorCode2
+            }.size)
+            assertEquals(customErrorCode1, lastStatusResults.find { it.resultId == customErrorCode1 }?.resultId)
+            assertEquals(customErrorCode2, lastStatusResults.find { it.resultId == customErrorCode2 }?.resultId)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    // Helper functions
 
     private fun validation(result : ValidationResult, failFast : Boolean = false)
             = mockk<Validation> {
@@ -199,6 +259,15 @@ class TriggerValidationsTest {
             delay(delayInMillis)
             result
         }
+    }
+
+    private suspend fun assertFieldStatusSequence(flowTurbine: FlowTurbine<FieldStatus>, vararg statuses: String): FieldStatus {
+        var lastValue :FieldStatus? = null
+        statuses.forEach {
+            lastValue = flowTurbine.awaitItem()
+            assertEquals(it, lastValue?.code)
+        }
+        return lastValue!!
     }
 
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/RequiredTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/RequiredTest.kt
@@ -2,31 +2,34 @@ package com.rootstrap.flowforms.core.validation
 
 import com.rootstrap.flowforms.core.common.StatusCodes.CORRECT
 import com.rootstrap.flowforms.core.common.StatusCodes.REQUIRED_UNSATISFIED
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class RequiredTest {
 
     @Test
-    fun `GIVEN a string with only spaces THEN assert the validation result is CORRECT`() {
+    fun `GIVEN a string with only spaces THEN assert the validation result is CORRECT`() = runTest {
         val required = Required { "   " }
         assertEquals(CORRECT, required.validate().resultId)
     }
 
     @Test
-    fun `GIVEN a string with some text THEN assert the validation result is CORRECT`() {
+    fun `GIVEN a string with some text THEN assert the validation result is CORRECT`() = runTest {
         val required = Required { "text" }
         assertEquals(CORRECT, required.validate().resultId)
     }
 
     @Test
-    fun `GIVEN a null value THEN assert the validation result is REQUIRED_UNSATISFIED`() {
+    fun `GIVEN a null value THEN assert the validation result is REQUIRED_UNSATISFIED`() = runTest {
         val required = Required { null }
         assertEquals(REQUIRED_UNSATISFIED, required.validate().resultId)
     }
 
     @Test
-    fun `GIVEN an empty string THEN assert the validation result is REQUIRED_UNSATISFIED`() {
+    fun `GIVEN an empty string THEN assert the validation result is REQUIRED_UNSATISFIED`() = runTest {
         val required = Required { "" }
         assertEquals(REQUIRED_UNSATISFIED, required.validate().resultId)
     }

--- a/README.md
+++ b/README.md
@@ -68,10 +68,11 @@ For more information check the [official notion page](https://www.notion.so/root
 We expect to have at least 90% of the code unit tested (with the ideal goal of 100%) in all modules except the Example apps. So please ensure to make unit tests on new code and keep all of them working.
 
 #### FlowForms Core
-As the current implementation is only a jvm one, to run the tests on the module **FlowForms Core** we need to write the following command in a Terminal at the project's root folder (or directly in the IDE's Terminal)
-- `./gradlew FlowForms-Core:jvmTest`
+To run the tests on the module **FlowForms Core** we need to write the following command in a Terminal at the project's root folder (or directly in the IDE's Terminal)
+- `./gradlew FlowForms-Core:check`
+The above command executes all the configured tests in the FlowForms-Core module while also generating coverage reports.
 
-**FlowForms Core** uses [Coroutines-test](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/README.md), [Mockk](https://github.com/mockk/mockk), and [Turbine](https://github.com/cashapp/turbine) for testing the common kotlin module.
+**FlowForms Core** uses [Kover](https://github.com/Kotlin/kotlinx-kover) for code coverage and [Coroutines-test](https://github.com/Kotlin/kotlinx.coroutines/blob/master/kotlinx-coroutines-test/README.md), [Mockk](https://github.com/mockk/mockk), and [Turbine](https://github.com/cashapp/turbine) for testing the common kotlin module.
 
 #### FlowForms Android Ext
 WIP 🚧


### PR DESCRIPTION
### Issue #11 

### Description :
 * Implemented async validations within an `injected coroutine dispatcher` (per call at the moment), allowing them to run based on the specified `coroutine dispatcher` rules, like running in parallel without blocking the caller's thread.
 * To use async validations the Field requires to have a coroutine scheduler specified in the triggerValidationsCall, otherwise it throws an IllegalStateException. This is something that should be improved in the near future with a default background IO coroutine scheduler (not available in common kotlin, is platform specific).
 * validations now have a suspend validate() function in order to ease the use of async and coroutine stuff in them (like calling an API using Retrofit or a Database using Room in Android).
 * Added code coverage support for KMP using `Kover`.
 * Generated tests for the handling of both sync and async validations together and alone in different situations, described in the tests names.
 * Updated expected and actual parameter order in the validation tests as they were reversed.
 * Now we can run the core module tests using `./gradlew FlowForms-Core:check` instead of `./gradlew FlowForms-Core:jvmTest`.
 * Updated Readme.
 * Closes #11 

### Notes : 
 * If an async validation fails while others are in progress, and the failing async validation has the `failFast` attribute as true, then the rest of validations are cancelled automatically and the corresponding validation result is returned.

### Screenshots :
Code coverage reports
<img width="1439" alt="Screen Shot 2022-06-21 at 14 27 08" src="https://user-images.githubusercontent.com/26490822/174865071-630802bf-618d-49f2-9882-9762ce4c83eb.png">
<img width="1439" alt="Screen Shot 2022-06-21 at 14 26 06" src="https://user-images.githubusercontent.com/26490822/174865092-909a8d1e-44f9-4bc6-b840-55abc068c2cb.png">

