### PR TITLE
Fragment example usage in Android example app

### DIFF
--- a/ExampleApp Android/src/main/AndroidManifest.xml
+++ b/ExampleApp Android/src/main/AndroidManifest.xml
@@ -10,7 +10,7 @@
         android:supportsRtl="true"
         android:theme="@style/Theme.FlowForms">
         <activity
-            android:name=".MainActivity"
+            android:name=".SignUpFormFragmentContainerActivity"
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormActivity.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormActivity.kt
@@ -1,6 +1,7 @@
 package com.rootstrap.flowforms.example
 
 import android.os.Bundle
+import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
@@ -14,25 +15,28 @@ import com.rootstrap.flowforms.example.SignUpFormModel.Companion.EMAIL
 import com.rootstrap.flowforms.example.SignUpFormModel.Companion.MIN_PASSWORD_LENGTH
 import com.rootstrap.flowforms.example.SignUpFormModel.Companion.NAME
 import com.rootstrap.flowforms.example.SignUpFormModel.Companion.NEW_PASSWORD
-import com.rootstrap.flowforms.example.databinding.ActivityMainBinding
+import com.rootstrap.flowforms.example.databinding.LayoutSimpleSignUpFormBinding
 import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.INVALID_EMAIL
 import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.MIN_LENGTH_UNSATISFIED
 import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.PASSWORD_MATCH_UNSATISFIED
 import com.rootstrap.flowforms.util.bind
 import com.rootstrap.flowforms.util.repeatOnLifeCycleScope
 
-class MainActivity : AppCompatActivity() {
+class SignUpFormActivity : AppCompatActivity() {
 
     private lateinit var viewModel: SignUpViewModel
-    private lateinit var binding: ActivityMainBinding
+    private lateinit var binding: LayoutSimpleSignUpFormBinding
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        binding = ActivityMainBinding.inflate(layoutInflater)
+        binding = LayoutSimpleSignUpFormBinding.inflate(layoutInflater)
         setContentView(binding.root)
         viewModel = ViewModelProvider(this)[SignUpViewModel::class.java]
         binding.lifecycleOwner = this
         binding.formModel = viewModel.formModel
+        binding.continueButton.setOnClickListener {
+            Toast.makeText(this, R.string.account_registered, Toast.LENGTH_SHORT).show()
+        }
 
         listenStatusChanges()
         bindFields()
@@ -58,7 +62,7 @@ class MainActivity : AppCompatActivity() {
                 passwordInputEditText to NEW_PASSWORD,
                 confirmPasswordInputEditText to CONFIRM_PASSWORD
             )
-            viewModel.form.bind(this@MainActivity, lifecycleScope,
+            viewModel.form.bind(this@SignUpFormActivity, lifecycleScope,
                 viewModel.formModel.confirm to CONFIRMATION
             )
         }

--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
@@ -1,0 +1,139 @@
+package com.rootstrap.flowforms.example
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.lifecycleScope
+import com.rootstrap.flowforms.core.common.StatusCodes.CORRECT
+import com.rootstrap.flowforms.core.common.StatusCodes.UNMODIFIED
+import com.rootstrap.flowforms.core.field.FieldStatus
+import com.rootstrap.flowforms.core.form.FormStatus
+import com.rootstrap.flowforms.example.SignUpFormModel.Companion.MIN_PASSWORD_LENGTH
+import com.rootstrap.flowforms.example.databinding.LayoutSimpleSignUpFormBinding
+import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.INVALID_EMAIL
+import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.MIN_LENGTH_UNSATISFIED
+import com.rootstrap.flowforms.example.validations.ValidEmail.Companion.PASSWORD_MATCH_UNSATISFIED
+import com.rootstrap.flowforms.util.bind
+import com.rootstrap.flowforms.util.repeatOnLifeCycleScope
+
+class SignUpFormFragment : Fragment() {
+
+    private var binding : LayoutSimpleSignUpFormBinding? = null
+    private lateinit var viewModel : SignUpViewModel
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return LayoutSimpleSignUpFormBinding
+            .inflate(layoutInflater, container, false)
+            .let {
+                binding = it
+                it.root
+            }
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        viewModel = ViewModelProvider(requireActivity())[SignUpViewModel::class.java]
+        binding?.let {
+            it.lifecycleOwner = viewLifecycleOwner
+            it.formModel = viewModel.formModel
+            it.continueButton.setOnClickListener {
+                Toast.makeText(requireContext(), R.string.account_registered, Toast.LENGTH_SHORT).show()
+            }
+        }
+        listenStatusChanges()
+        bindFields()
+    }
+
+    private fun listenStatusChanges() {
+        viewModel.form.fields.value.let {
+            repeatOnLifeCycleScope(
+                { it[SignUpFormModel.NAME]?.status?.collect(::onNameStatusChange) },
+                { it[SignUpFormModel.EMAIL]?.status?.collect(::onEmailStatusChange) },
+                { it[SignUpFormModel.NEW_PASSWORD]?.status?.collect(::onPasswordStatusChange) },
+                { it[SignUpFormModel.CONFIRM_PASSWORD]?.status?.collect(::onConfirmPasswordChange) },
+                { viewModel.form.status.collect(::onFormStatusChange) }
+            )
+        }
+    }
+
+    private fun bindFields() {
+        binding?.apply {
+            viewModel.form.bind(lifecycleScope,
+                nameInputEditText to SignUpFormModel.NAME,
+                emailInputEditText to SignUpFormModel.EMAIL,
+                passwordInputEditText to SignUpFormModel.NEW_PASSWORD,
+                confirmPasswordInputEditText to SignUpFormModel.CONFIRM_PASSWORD
+            )
+            viewModel.form.bind(this@SignUpFormFragment, lifecycleScope,
+                viewModel.formModel.confirm to SignUpFormModel.CONFIRMATION
+            )
+        }
+    }
+
+    private fun onNameStatusChange(status: FieldStatus) {
+        binding?.apply {
+            when (status.code) {
+                CORRECT, UNMODIFIED -> nameInputLayout.error = null
+                else -> nameInputLayout.error = getString(R.string.required_field)
+            }
+        }
+    }
+
+    private fun onEmailStatusChange(status: FieldStatus) {
+        binding?.apply {
+            when (status.code) {
+                CORRECT, UNMODIFIED -> emailInputLayout.error = null
+                INVALID_EMAIL -> emailInputLayout.error = getString(R.string.invalid_email)
+                else -> emailInputLayout.error = getString(R.string.required_field)
+            }
+        }
+    }
+
+    private fun onPasswordStatusChange(status: FieldStatus) {
+        binding?.apply {
+            when (status.code) {
+                CORRECT, UNMODIFIED -> passwordInputLayout.error = null
+                MIN_LENGTH_UNSATISFIED -> passwordInputLayout.error = getString(R.string.min_length,
+                    MIN_PASSWORD_LENGTH
+                )
+                else -> passwordInputLayout.error = getString(R.string.required_field)
+            }
+        }
+    }
+
+    private fun onConfirmPasswordChange(status: FieldStatus) {
+        binding?.apply {
+            when (status.code) {
+                CORRECT, UNMODIFIED -> confirmPasswordInputLayout.error = null
+                MIN_LENGTH_UNSATISFIED -> confirmPasswordInputLayout.error = getString(R.string.min_length,
+                    MIN_PASSWORD_LENGTH
+                )
+                PASSWORD_MATCH_UNSATISFIED -> confirmPasswordInputLayout.error = getString(R.string.password_match)
+                else -> confirmPasswordInputLayout.error = getString(R.string.required_field)
+            }
+        }
+    }
+
+    private fun onFormStatusChange(status: FormStatus) {
+        binding?.apply {
+            when (status.code) {
+                CORRECT -> continueButton.isEnabled = true
+                else -> continueButton.isEnabled = false
+            }
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        binding = null
+    }
+
+}

--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragmentContainerActivity.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragmentContainerActivity.kt
@@ -1,0 +1,17 @@
+package com.rootstrap.flowforms.example
+
+import android.os.Bundle
+import androidx.appcompat.app.AppCompatActivity
+import com.rootstrap.flowforms.example.databinding.ActivitySimpleSignUpFragmentFormBinding
+
+class SignUpFormFragmentContainerActivity : AppCompatActivity() {
+
+    private lateinit var binding : ActivitySimpleSignUpFragmentFormBinding
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivitySimpleSignUpFragmentFormBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+    }
+
+}

--- a/ExampleApp Android/src/main/res/layout/activity_simple_sign_up_fragment_form.xml
+++ b/ExampleApp Android/src/main/res/layout/activity_simple_sign_up_fragment_form.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent">
+
+        <androidx.fragment.app.FragmentContainerView
+            android:id="@+id/fragment"
+            android:name="com.rootstrap.flowforms.example.SignUpFormFragment"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"/>
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+</layout>

--- a/ExampleApp Android/src/main/res/layout/layout_simple_sign_up_form.xml
+++ b/ExampleApp Android/src/main/res/layout/layout_simple_sign_up_form.xml
@@ -5,7 +5,6 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <data>
-
         <variable
             name="formModel"
             type="com.rootstrap.flowforms.example.SignUpFormModel" />
@@ -14,7 +13,7 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
-        tools:context=".MainActivity">
+        tools:context=".SignUpFormActivity">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/name_input_layout"

--- a/ExampleApp Android/src/main/res/values/strings.xml
+++ b/ExampleApp Android/src/main/res/values/strings.xml
@@ -10,4 +10,5 @@
     <string name="invalid_email">This email is invalid</string>
     <string name="min_length">This field should have %1$d characters</string>
     <string name="password_match">The passwords don\'t match</string>
+    <string name="account_registered">Account registered</string>
 </resources>

--- a/FlowForms-Core/src/androidMain/kotlin/com/rootstrap/flowforms/util/FlowFormsUtils.kt
+++ b/FlowForms-Core/src/androidMain/kotlin/com/rootstrap/flowforms/util/FlowFormsUtils.kt
@@ -4,6 +4,7 @@ import android.view.View
 import android.widget.EditText
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.widget.doAfterTextChanged
+import androidx.fragment.app.Fragment
 import androidx.lifecycle.*
 import com.rootstrap.flowforms.core.field.FlowField
 import com.rootstrap.flowforms.core.form.FlowForm
@@ -21,6 +22,25 @@ import kotlinx.coroutines.launch
  * @param lifecycleState lifecycle phase used by the [repeatOnLifecycle] call. By default it is [Lifecycle.State.STARTED]
  */
 fun AppCompatActivity.repeatOnLifeCycleScope(
+    vararg blocks : suspend () -> Unit,
+    lifecycleState : Lifecycle.State = Lifecycle.State.STARTED
+) {
+    lifecycleScope.launch {
+        repeatOnLifecycle(lifecycleState) {
+            blocks.forEach {
+                launch {
+                    it()
+                }
+            }
+        }
+    }
+}
+
+/**
+ * Exactly the same as [AppCompatActivity.repeatOnLifeCycleScope] but for fragments!
+ *
+ */
+fun Fragment.repeatOnLifeCycleScope(
     vararg blocks : suspend () -> Unit,
     lifecycleState : Lifecycle.State = Lifecycle.State.STARTED
 ) {


### PR DESCRIPTION
Please remember to add the proper labels to the PR. You can delete
the template sections that don't apply to this PR. Remove this message.

#### ISSUE #25 
* closes #25 

---

#### Description
* Implemented the fragment form usage example, very similar to the activity example. In fact 80% is the same but we kept it duplicated to serve as a practical and easy to understand usage example.
* Created basic activity to display the fragment.
* Added an extension for fragments to collect repeating on lifecycle, which is the same as the activity one but for fragments.
* Updated Android example app's manifest.xml to load the fragment form instead of the activity one.
* Renamed current example files to be more clear on what is the form about.
* Added a Toast on continue button's click on both fragment and activity examples.

---

#### Notes
 * The PR points to feature/android-utilities because it depends on it and that branch was not merged yet.

---

#### Preview
* Fragment example with the toast after a correct sign up:
<img width="283" alt="image" src="https://user-images.githubusercontent.com/26490822/186212312-942d3644-576c-4cb2-9bb0-71a83d7ef05b.png">

