### PR TITLE
Android library publishing. Version update to 0.0.3

### DIFF
--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -9,7 +9,9 @@ group = "com.rootstrap"
 version = "0.0.2"
 
 kotlin {
-    android()
+    android {
+        publishLibraryVariants("release")
+    }
     jvm {
         testRuns["test"].executionTask.configure {
             useJUnitPlatform()
@@ -55,6 +57,12 @@ android {
     defaultConfig {
         minSdk = 23
         targetSdk = 32
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
     }
 }
 

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.rootstrap"
-version = "0.0.2"
+version = "0.0.3"
 
 kotlin {
     android {

--- a/README.md
+++ b/README.md
@@ -32,15 +32,18 @@ allprojects {
 ```kotlin
 dependencies {
   ..
-  val flowFormsVersion = "0.0.2"
+  val flowFormsVersion = "0.0.3"
+    
+  // Use this to get FlowForms Core module on Android 
+  implementation("com.github.rootstrap.FlowForms:FlowForms-Core-android:$flowFormsVersion")
 
-  // Use this to get FlowForms Core module only for jvm targets
+  // Use this to get FlowForms Core module on jvm targets
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core-jvm:$flowFormsVersion")
 
   // Use this to get the whole FlowForms Core module (for all available targets)
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")
   
-  // Use this to get every FlowForms modules together (currently we only have FlowForms Core so it's the same as above) 
+  // Use this to get every FlowForms modules together (currently we only have FlowForms Core so it's the same as above but shorter) 
   implementation("com.github.rootstrap:FlowForms:$flowFormsVersion")
   ..
 }

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,2 @@
+jdk:
+  openjdk11


### PR DESCRIPTION
#### ISSUE none

---

#### Description
* To publish an .aar (android library) with Kotlin multiplatform in Jitpack, we need some additional setup.
* Updated version to 0.0.3 to trigger the new builds via a new release.
* Already tested with manual Jitpack building of [this branch](https://jitpack.io/#rootstrap/FlowForms/feature~android-lib-publishing-2a0f5bd008-1)
* The project will build and publish the following artifacts in Jitpack : 
`FlowForms-Core` (Kotlin multi-platform) 
`FlowForms-Core-android` (Including android specific utilities) 
`FlowForms-Core-jvm` (without android utilities, and for jvm targets)

