### PR TITLE
Fix documentation responsiveness on mobile screens. Upgrade to version 1.0.0

### DIFF
--- a/ExampleApp Android/build.gradle.kts
+++ b/ExampleApp Android/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = (ExampleAppAndroidConfig.MIN_SDK)
         targetSdk = (ExampleAppAndroidConfig.TARGET_SDK)
         versionCode = 1
-        versionName = "0.0.2"
+        versionName = "1.0.0"
 
         testInstrumentationRunner = ExampleAppAndroidConfig.ANDROID_TEST_INSTRUMENTATION_RUNNER
     }

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.rootstrap"
-version = "0.0.3"
+version = "1.0.0"
 
 kotlin {
     android {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Based on your project, add FlowForms dependency in your module's build.gradle fi
 ```kotlin
 dependencies {
   ..
-  val flowFormsVersion = "0.0.3"
+  val flowFormsVersion = "1.0.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{{ page.title }}</title>
     <link rel="stylesheet" href="{{site.baseurl}}/assets/css/styles.css">
     <link rel="stylesheet" href="{{site.baseurl}}/assets/css/fontawesome.all.min.css">

--- a/docs/_sass/main.scss
+++ b/docs/_sass/main.scss
@@ -1,11 +1,9 @@
 html {
-
   padding: 3em 1em;
   margin: auto;
   line-height: 1.75;
   font-size: 1em;
   text-align: justify;
-  
 }
 
 h1,h2,h3,h4,h5,h6 {
@@ -147,6 +145,8 @@ a {
   top: 0px;
   left: 0px;
   padding: 0px;
+  bottom: 0px;
+  margin-bottom: 0px;
   transform: translate(-200px, 0px);
   transition: all 0.4s ease 0s;
 }
@@ -189,8 +189,10 @@ a {
 #sidebar-wrapper .sidebar-nav {
   background: #2b2b2b;
   width: 200px;
-  height: 100vh;
+  height: 100%;
   margin-top: 0px;
+  overflow-y: auto;
+  overflow-x: hidden;
   padding: 0px;
   position: fixed;
   left: 0px;

--- a/docs/_sass/main.scss
+++ b/docs/_sass/main.scss
@@ -100,6 +100,7 @@ a {
 
 .badges-container {
   margin-top: 16px;
+  flex-wrap: wrap;
 }
 
 .badges-container a {
@@ -202,13 +203,6 @@ a {
   transition: all 0.5s ease;
 }
 
-@media only screen and (max-width: 768px) {
-  
-  #sidebar-empty-space {
-    display: none;
-  }
-}
-
 #page-content-wrapper {
   width: 100%;
 }
@@ -255,4 +249,20 @@ a {
 
 .current-nav-option {
   color: green;
+}
+
+@media only screen and (max-width: 768px) {
+  
+  #sidebar-empty-space {
+    display: none;
+  }
+
+  html {
+    padding: 3em 1em;
+    margin: auto;
+    line-height: 1.75;
+    font-size: 1em;
+    text-align: start;
+  }
+
 }

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Add FlowForms dependency in your module's build.gradle file :
 <pre><code class="kotlin">
 dependencies {
   ..
-  val flowFormsVersion = "0.0.3"
+  val flowFormsVersion = "1.0.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ title: Flow Forms, Declarative and reactive form management library
 
 <div class="rs-column center-second-axis"> 
     <a href="http://www.rootstrap.com"> <img src="https://s3-us-west-1.amazonaws.com/rootstrap.com/img/rs.png" width="100"/> </a>
-    <img src="{{site.baseurl}}/images/logotype-FlowForms-transparent.png" width="400" class="logotype-header"> 
+    <img src="{{site.baseurl}}/images/logotype-FlowForms-transparent.png" width="75%" class="logotype-header"> 
     <div class="rs-row center-main-axis badges-container"> 
       <a href="https://jitpack.io/#rootstrap/FlowForms"> <img src="https://jitpack.io/v/rootstrap/FlowForms.svg" /> </a> 
       <a href="https://www.contributor-covenant.org/version/2/1/code_of_conduct/"> <img src="https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg" /> </a>


### PR DESCRIPTION
#### ISSUE Pending mobile issue on library docs 

---

#### Description
* Fixed an issue on small screens when viewing the library documentation.
* Updated library version to 1.0.0

---

#### Preview


https://user-images.githubusercontent.com/26490822/204398217-0c7bb2d5-3564-455c-9e56-e03ce950b8ec.mov

