### PR TITLE
Cross-field validations tests and added a direct way to get form's fields

### DIFF
--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormActivity.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormActivity.kt
@@ -46,13 +46,13 @@ class SignUpFormActivity : AppCompatActivity() {
     }
 
     private fun listenStatusChanges() {
-        viewModel.form.fields.value.let {
+        viewModel.form.apply {
             repeatOnLifeCycleScope(
-                { it[NAME]?.status?.collect(::onNameStatusChange) },
-                { it[EMAIL]?.status?.collect(::onEmailStatusChange) },
-                { it[PASSWORD]?.status?.collect(::onPasswordStatusChange) },
-                { it[CONFIRM_PASSWORD]?.status?.collect(::onConfirmPasswordChange) },
-                { viewModel.form.status.collect(::onFormStatusChange) }
+                { field(NAME)?.status?.collect(::onNameStatusChange) },
+                { field(EMAIL)?.status?.collect(::onNameStatusChange) },
+                { field(PASSWORD)?.status?.collect(::onNameStatusChange) },
+                { field(CONFIRM_PASSWORD)?.status?.collect(::onNameStatusChange) },
+                { status.collect(::onFormStatusChange) }
             )
         }
     }

--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
@@ -17,7 +17,11 @@ import com.rootstrap.flowforms.core.common.StatusCodes.REQUIRED_UNSATISFIED
 import com.rootstrap.flowforms.core.field.FieldStatus
 import com.rootstrap.flowforms.core.form.FormStatus
 import com.rootstrap.flowforms.example.EmailDoesNotExistsInRemoteStorage.ResultCode.EMAIL_ALREADY_EXISTS
+import com.rootstrap.flowforms.example.SignUpFormModel.Companion.CONFIRM_PASSWORD
+import com.rootstrap.flowforms.example.SignUpFormModel.Companion.EMAIL
 import com.rootstrap.flowforms.example.SignUpFormModel.Companion.MIN_PASSWORD_LENGTH
+import com.rootstrap.flowforms.example.SignUpFormModel.Companion.NAME
+import com.rootstrap.flowforms.example.SignUpFormModel.Companion.PASSWORD
 import com.rootstrap.flowforms.example.databinding.LayoutSimpleSignUpFormBinding
 import com.rootstrap.flowforms.util.bind
 import com.rootstrap.flowforms.util.repeatOnLifeCycleScope
@@ -55,13 +59,13 @@ class SignUpFormFragment : Fragment() {
     }
 
     private fun listenStatusChanges() {
-        viewModel.form.fields.value.let {
+        viewModel.form.apply {
             repeatOnLifeCycleScope(
-                { it[SignUpFormModel.NAME]?.status?.collect(::onNameStatusChange) },
-                { it[SignUpFormModel.EMAIL]?.status?.collect(::onEmailStatusChange) },
-                { it[SignUpFormModel.PASSWORD]?.status?.collect(::onPasswordStatusChange) },
-                { it[SignUpFormModel.CONFIRM_PASSWORD]?.status?.collect(::onConfirmPasswordChange) },
-                { viewModel.form.status.collect(::onFormStatusChange) }
+                { field(NAME)?.status?.collect(::onNameStatusChange) },
+                { field(EMAIL)?.status?.collect(::onEmailStatusChange) },
+                { field(PASSWORD)?.status?.collect(::onPasswordStatusChange) },
+                { field(CONFIRM_PASSWORD)?.status?.collect(::onConfirmPasswordChange) },
+                { status.collect(::onFormStatusChange) }
             )
         }
     }
@@ -69,10 +73,10 @@ class SignUpFormFragment : Fragment() {
     private fun bindFields() {
         binding?.apply {
             viewModel.form.bind(lifecycleScope,
-                nameInputEditText to SignUpFormModel.NAME,
-                emailInputEditText to SignUpFormModel.EMAIL,
-                passwordInputEditText to SignUpFormModel.PASSWORD,
-                confirmPasswordInputEditText to SignUpFormModel.CONFIRM_PASSWORD
+                nameInputEditText to NAME,
+                emailInputEditText to EMAIL,
+                passwordInputEditText to PASSWORD,
+                confirmPasswordInputEditText to CONFIRM_PASSWORD
             )
             viewModel.form.bind(this@SignUpFormFragment, lifecycleScope,
                 viewModel.formModel.confirm to SignUpFormModel.CONFIRMATION

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehavior.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehavior.kt
@@ -36,7 +36,7 @@ class DefaultFieldValidationBehavior : FieldValidationBehavior {
     ) : Boolean {
         val (asyncValidations, syncValidations) = validations.partition { it.async }
         if (asyncValidations.isNotEmpty() && asyncCoroutineDispatcher == null) {
-            throw IllegalStateException("Async coroutine dispatcher could not be null in order to use async validations")
+            throw IllegalStateException("Async coroutine dispatcher could not be null in order to use async validations. Did you forget to set the dispatcher variable on the form declaration?")
         }
 
         val validationProcessData = ValidationProcessData(

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
@@ -75,6 +75,15 @@ class FlowForm internal constructor(
     }
 
     /**
+     * Returns the field with the given ID, or null if it doesn't exist on this form
+     * at this specific moment.
+     *
+     * @param id the ID of the field to retrieve.
+     * @return a FieldDefinition instance for the given ID, or null.
+     */
+    fun field(id: String) = fields.value[id]
+
+    /**
      * Trigger onValueChange validations on the specified [FlowField] (if it exists in this form).
      *
      * For additional information please refer to [DOC_FIELD_VALIDATION_BEHAVIOR]

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
@@ -169,7 +169,7 @@ class FlowForm internal constructor(
 
         for (validationsPerField in crossFieldValidations) {
             val targetField = _fields.value[validationsPerField.key] ?: continue
-            val validations = validationsPerField.value
+            val validations = validationsPerField.value.map { it.validation }
             if (targetField.getCurrentStatus().code != UNMODIFIED) {
                 when (validationType) {
                     ON_VALUE_CHANGE ->

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/FlowFieldTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/FlowFieldTest.kt
@@ -4,9 +4,13 @@ package com.rootstrap.flowforms.core.field
 
 import app.cash.turbine.test
 import com.rootstrap.flowforms.core.common.StatusCodes
+import com.rootstrap.flowforms.core.common.StatusCodes.CORRECT
+import com.rootstrap.flowforms.core.common.StatusCodes.IN_PROGRESS
+import com.rootstrap.flowforms.core.common.StatusCodes.UNMODIFIED
 import com.rootstrap.flowforms.core.util.assertFieldStatusSequence
 import com.rootstrap.flowforms.core.util.asyncValidation
 import com.rootstrap.flowforms.core.util.getTestDispatcher
+import com.rootstrap.flowforms.core.util.validation
 import com.rootstrap.flowforms.core.validation.Validation
 import com.rootstrap.flowforms.core.validation.ValidationResult
 import com.rootstrap.flowforms.core.validation.ValidationsCancelledException
@@ -16,6 +20,7 @@ import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
@@ -27,7 +32,7 @@ class FlowFieldTest {
     fun `GIVEN a new required field THEN assert its status is UNMODIFIED`() = runTest {
         val field = FlowField("email")
         field.status.test {
-            assertEquals(awaitItem().code, StatusCodes.UNMODIFIED)
+            assertEquals(awaitItem().code, UNMODIFIED)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -58,7 +63,7 @@ class FlowFieldTest {
                     println("First async validation was cancelled : ${ex.message}")
                 }
             }
-            assertFieldStatusSequence(this, StatusCodes.UNMODIFIED, StatusCodes.IN_PROGRESS)
+            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS)
             launch {
                 field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
             }
@@ -69,6 +74,85 @@ class FlowFieldTest {
             coVerify(exactly = 1) { asyncValidation.validate() }
 
             cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN a field WHEN status change from UNMODIFIED to IN_PROGRESS to CORRECT THEN assert getCurrentStatus gives the respective status on each stage`()
+        = runTest {
+        val fieldValidationBehavior = mockk<FieldValidationBehavior> {}
+        val field = FlowField("id", validationBehavior = fieldValidationBehavior)
+
+        coEvery {
+            fieldValidationBehavior.triggerValidations(mutableFieldStatus = any(), emptyList())
+        } coAnswers {
+            val onValueChangeStatusFlow = it.invocation.args[0] as MutableStateFlow<FieldStatus>
+            when (onValueChangeStatusFlow.value.code) {
+                UNMODIFIED -> {
+                    onValueChangeStatusFlow.value = FieldStatus(IN_PROGRESS)
+                    false
+                }
+                IN_PROGRESS -> {
+                    onValueChangeStatusFlow.value = FieldStatus(CORRECT)
+                    true
+                }
+                else -> {
+                    onValueChangeStatusFlow.value = FieldStatus(UNMODIFIED)
+                    false
+                }
+            }
+        }
+
+        field.status.test {
+            awaitItem() // ignores first unmodified initial state (because of empty validation list)
+
+            field.triggerOnValueChangeValidations()
+            awaitItem()
+            assertEquals(UNMODIFIED, field.getCurrentStatus().code)
+
+            field.triggerOnValueChangeValidations()
+            awaitItem()
+            assertEquals(IN_PROGRESS, field.getCurrentStatus().code)
+
+            field.triggerOnValueChangeValidations()
+            awaitItem()
+            assertEquals(CORRECT, field.getCurrentStatus().code)
+
+            cancelAndConsumeRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `GIVEN a field with a validation WHEN it is validated with a different validation then assert the fields validations are not used`()
+    = runTest {
+        val fieldValidations = listOf(
+            validation(ValidationResult.Correct, true)
+        )
+        val customValidations = listOf(
+            validation(ValidationResult.Incorrect, false)
+        )
+        val fieldValidationBehavior = mockk<FieldValidationBehavior> {
+            coEvery {
+                triggerValidations(mutableFieldStatus = any(), any(), any())
+            } coAnswers { true }
+        }
+        val field = FlowField(
+            "id",
+            onValueChangeValidations = fieldValidations,
+            onFocusValidations = fieldValidations,
+            onBlurValidations = fieldValidations,
+            validationBehavior = fieldValidationBehavior
+        )
+
+        field.triggerOnValueChangeValidations(validations = customValidations)
+        field.triggerOnFocusValidations(validations = customValidations)
+        field.triggerOnBlurValidations(validations = customValidations)
+
+        coVerify(exactly = 0) {
+            fieldValidationBehavior.triggerValidations(any(), fieldValidations, any())
+        }
+        coVerify(exactly = 3) {
+            fieldValidationBehavior.triggerValidations(any(), customValidations, any())
         }
     }
 

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.test.runTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
+import kotlin.test.assertNull
 import kotlin.test.fail
 
 @OptIn(ExperimentalCoroutinesApi::class)
@@ -53,9 +54,9 @@ class FlowFormTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus())
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus())
 
         flowForm {
@@ -72,9 +73,9 @@ class FlowFormTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus(), FieldStatus(INCORRECT))
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus())
 
         flowForm {
@@ -88,13 +89,13 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 2 fields WHEN one field become correct THEN assert the form status changes from UNMODIFIED to INCOMPLETE`()
-            = runTest {
+    = runTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus())
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
 
         flowForm {
@@ -108,13 +109,13 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 2 fields WHEN both fields become correct at the same time THEN assert the form status changes from UNMODIFIED to CORRECT`()
-            = runTest {
+    = runTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
 
         flowForm {
@@ -128,18 +129,18 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 3 fields WHEN only two fields become correct at different times THEN assert the form status changes from UNMODIFIED to INCOMPLETE`()
-            = runTest {
+    = runTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
         val field3 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
 
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
 
-        every { field3.id } returns "field3"
+        every { field3.id } returns FIELD_ID_3
         every { field3.status } returns flowOf(FieldStatus())
 
         flowForm {
@@ -154,18 +155,18 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 3 fields WHEN one field become correct and one become incorrect THEN assert the form status changes from UNMODIFIED to INCOMPLETE TO INCORRECT`()
-            = runTest {
+    = runTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
         val field3 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(INCORRECT))
 
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
 
-        every { field3.id } returns "field3"
+        every { field3.id } returns FIELD_ID_3
         every { field3.status } returns flowOf(FieldStatus())
 
         flowForm {
@@ -180,18 +181,18 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 3 fields WHEN they become correct at different times THEN assert the form status changes from UNMODIFIED to INCOMPLETE x2 to CORRECT`()
-            = runTest {
+    = runTest {
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
         val field3 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
 
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
 
-        every { field3.id } returns "field3"
+        every { field3.id } returns FIELD_ID_3
         every { field3.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
 
         flowForm {
@@ -207,11 +208,11 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with a field for each validation option WHEN calling the form's validation methods THEN assert the fields corresponding validations are triggered exactly once`()
-            = runTest {
+    = runTest {
         val coroutineDispatcher = StandardTestDispatcher(testScheduler, name = TEST_IO_DISPATCHER_NAME)
-        val field1 = mockkFlowField(id = "field1")
-        val field2 = mockkFlowField(id = "field2")
-        val field3 = mockkFlowField(id = "field3")
+        val field1 = mockkFlowField(id = FIELD_ID_1)
+        val field2 = mockkFlowField(id = FIELD_ID_2)
+        val field3 = mockkFlowField(id = FIELD_ID_3)
 
         coEvery { field1.triggerOnValueChangeValidations(coroutineDispatcher) } returns true
         coEvery { field2.triggerOnBlurValidations(coroutineDispatcher) } returns true
@@ -223,9 +224,9 @@ class FlowFormTest {
         }
 
         form.status.test {
-            form.validateOnValueChange("field1")
-            form.validateOnBlur("field2")
-            form.validateOnFocus("field3")
+            form.validateOnValueChange(FIELD_ID_1)
+            form.validateOnBlur(FIELD_ID_2)
+            form.validateOnFocus(FIELD_ID_3)
 
             coVerify(exactly = 1) { field1.triggerOnValueChangeValidations(coroutineDispatcher) }
             coVerify(exactly = 1) { field2.triggerOnBlurValidations(coroutineDispatcher) }
@@ -237,7 +238,7 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form without fields WHEN the validate methods are called THEN assert the app does not crashes`()
-            = runTest {
+    = runTest {
         val form = flowForm { }
         val nonExistentFieldId = "fieldNonExistent"
 
@@ -253,7 +254,7 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form without fields WHEN calling the form's validate functions THEN assert the results are all false `()
-            = runTest {
+    = runTest {
         val form = flowForm { }
         val nonExistentFieldId = ""
 
@@ -267,10 +268,10 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with two fields with each kind of validation WHEN calling the form's validateAll method and the validations are correct THEN assert all the fields validations are triggered`()
-            = runTest {
+    = runTest {
         val coroutineDispatcher = StandardTestDispatcher(testScheduler, name = TEST_IO_DISPATCHER_NAME)
-        val field1 = mockkFlowField("field1")
-        val field2 = mockkFlowField("field2")
+        val field1 = mockkFlowField(FIELD_ID_1)
+        val field2 = mockkFlowField(FIELD_ID_2)
 
         coEvery { field1.triggerOnValueChangeValidations(coroutineDispatcher) } returns true
         coEvery { field1.triggerOnFocusValidations(coroutineDispatcher) } returns true
@@ -302,18 +303,18 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with two fields with each kind of validation WHEN calling the form's validateAll method and at onValueChange it is not correct THEN assert only onValueChangeValidations were triggered`()
-            = runTest {
+    = runTest {
         val coroutineDispatcher = StandardTestDispatcher(testScheduler, name = TEST_IO_DISPATCHER_NAME)
         val field1 = mockk<FlowField>()
         val field2 = mockk<FlowField>()
 
-        every { field1.id } returns "field1"
+        every { field1.id } returns FIELD_ID_1
         every { field1.status } returns flowOf(FieldStatus())
         coEvery { field1.triggerOnValueChangeValidations(coroutineDispatcher) } returns false
         coEvery { field1.triggerOnFocusValidations(coroutineDispatcher) } returns true
         coEvery { field1.triggerOnBlurValidations(coroutineDispatcher) } returns true
 
-        every { field2.id } returns "field2"
+        every { field2.id } returns FIELD_ID_2
         every { field2.status } returns flowOf(FieldStatus())
         coEvery { field2.triggerOnValueChangeValidations(coroutineDispatcher) } returns false
         coEvery { field2.triggerOnFocusValidations(coroutineDispatcher) } returns true
@@ -341,11 +342,11 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with two fields with each kind of validation WHEN calling the form's validateAll method and at onFocus it is not correct THEN assert that onBlur validations were not triggered`()
-            = runTest {
+    = runTest {
         val coroutineDispatcher = StandardTestDispatcher(testScheduler, name = TEST_IO_DISPATCHER_NAME)
 
-        val field1 = mockkFlowField("field1")
-        val field2 = mockkFlowField("field2")
+        val field1 = mockkFlowField(FIELD_ID_1)
+        val field2 = mockkFlowField(FIELD_ID_2)
 
         coEvery { field1.triggerOnValueChangeValidations(coroutineDispatcher) } returns true
         coEvery { field1.triggerOnFocusValidations(coroutineDispatcher) } returns false
@@ -378,11 +379,9 @@ class FlowFormTest {
     @Test
     fun `GIVEN a form with 1 CORRECT field with cross-field validations and, 1 CORRECT and 1 INCORRECT fields WHEN field one is validated THEN assert the other fields are also validated`()
     = runTest {
-        val field2Id = "field2"
-        val field3Id = "field3"
-        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), field2Id)
-        val crossFieldValidation2 = CrossFieldValidation(validation(ValidationResult.Correct), field2Id)
-        val crossFieldValidation3 = CrossFieldValidation(validation(ValidationResult.Correct), field3Id)
+        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), FIELD_ID_2)
+        val crossFieldValidation2 = CrossFieldValidation(validation(ValidationResult.Correct), FIELD_ID_2)
+        val crossFieldValidation3 = CrossFieldValidation(validation(ValidationResult.Correct), FIELD_ID_3)
         val field1RegularValidation = validation(ValidationResult.Correct)
 
         val field1Validations = listOf(
@@ -393,18 +392,18 @@ class FlowFormTest {
         )
         val field2Validations = listOf(validation(ValidationResult.Correct, failFast = true))
 
-        val field1 = mockkFlowField("field1", allValidationsList = field1Validations)
+        val field1 = mockkFlowField(FIELD_ID_1, allValidationsList = field1Validations)
         coEvery { field1.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field1.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field1.triggerOnBlurValidations(any(), any()) } returns true
 
-        val field2 = mockkFlowField(field2Id, allValidationsList = field2Validations)
+        val field2 = mockkFlowField(FIELD_ID_2, allValidationsList = field2Validations)
         coEvery { field2.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field2.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field2.triggerOnBlurValidations(any(), any()) } returns true
         every { field2.getCurrentStatus() } returns FieldStatus(CORRECT)
 
-        val field3 = mockkFlowField(field3Id)
+        val field3 = mockkFlowField(FIELD_ID_3)
         coEvery { field3.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field3.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field3.triggerOnBlurValidations(any(), any()) } returns true
@@ -454,8 +453,7 @@ class FlowFormTest {
     @Test
     fun `GIVEN a form with 1 CORRECT field with cross-field validations and 1 UNMODIFIED field WHEN the field one is validated THEN assert the other field is not`()
     = runTest {
-        val field2Id = "field2"
-        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), field2Id)
+        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), FIELD_ID_2)
         val field1RegularValidation = validation(ValidationResult.Correct)
 
         val field1Validations = listOf(
@@ -464,12 +462,12 @@ class FlowFormTest {
         )
         val field2Validations = listOf(validation(ValidationResult.Correct, failFast = true))
 
-        val field1 = mockkFlowField("field1", allValidationsList = field1Validations)
+        val field1 = mockkFlowField(FIELD_ID_1, allValidationsList = field1Validations)
         coEvery { field1.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field1.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field1.triggerOnBlurValidations(any(), any()) } returns true
 
-        val field2 = mockkFlowField(field2Id, allValidationsList = field2Validations)
+        val field2 = mockkFlowField(FIELD_ID_2, allValidationsList = field2Validations)
         coEvery { field2.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field2.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field2.triggerOnBlurValidations(any(), any()) } returns true
@@ -507,18 +505,17 @@ class FlowFormTest {
     @Test
     fun `GIVEN a form with 1 INCORRECT field with cross-field validations and 1 UNMODIFIED field WHEN field one is validated THEN assert the other field is not`()
     = runTest {
-        val field2Id = "field2"
-        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), field2Id)
+        val crossFieldValidation = CrossFieldValidation(validation(ValidationResult.Correct), FIELD_ID_2)
         val field1RegularValidation = validation(ValidationResult.Incorrect)
         val field1Validations = listOf(
             field1RegularValidation,
             crossFieldValidation,
         )
-        val field1 = mockkFlowField("field1", allValidationsList = field1Validations)
+        val field1 = mockkFlowField(FIELD_ID_1, allValidationsList = field1Validations)
         coEvery { field1.triggerOnValueChangeValidations(any(), any()) } returns false
         coEvery { field1.triggerOnFocusValidations(any(), any()) } returns false
         coEvery { field1.triggerOnBlurValidations(any(), any()) } returns false
-        val field2 = mockkFlowField(field2Id)
+        val field2 = mockkFlowField(FIELD_ID_2)
 
         val form = flowForm {
             fields(field1, field2)
@@ -558,7 +555,7 @@ class FlowFormTest {
             field1RegularValidation,
             crossFieldValidation,
         )
-        val field1 = mockkFlowField("field1", allValidationsList = field1Validations)
+        val field1 = mockkFlowField(FIELD_ID_1, allValidationsList = field1Validations)
         coEvery { field1.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field1.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field1.triggerOnBlurValidations(any(), any()) } returns true
@@ -586,8 +583,8 @@ class FlowFormTest {
 
     @Test
     fun `GIVEN a form with 1 field WHEN validation process is cancelled THEN assert the validation result is false`()
-            = runTest {
-        val field1 = mockkFlowField("field1")
+    = runTest {
+        val field1 = mockkFlowField(FIELD_ID_1)
         coEvery { field1.triggerOnValueChangeValidations(any(), any()) } throws ValidationsCancelledException("test exeption")
         coEvery { field1.triggerOnFocusValidations(any(), any()) } throws ValidationsCancelledException("test exeption")
         coEvery { field1.triggerOnBlurValidations(any(), any()) } throws ValidationsCancelledException("test exeption")
@@ -601,6 +598,34 @@ class FlowFormTest {
         assertFalse { form.validateOnBlur(field1.id) }
     }
 
+    @Test
+    fun `GIVEN a form with 2 fields WHEN getting them by id THEN assert they are retrieved`() {
+        val field1 = mockkFlowField(FIELD_ID_1)
+        val field2 = mockkFlowField(FIELD_ID_2)
+
+        val form = flowForm {
+            fields(field1, field2)
+        }
+
+        assertEquals(field1, form.field(FIELD_ID_1))
+        assertEquals(field2, form.field(FIELD_ID_2))
+    }
+
+    @Test
+    fun `GIVEN a form WHEN getting a field with an incorrect id THEN assert null is retrieved`() {
+        val field1 = mockkFlowField(FIELD_ID_1)
+        val field2 = mockkFlowField(FIELD_ID_2)
+
+        val form = flowForm {
+            fields(field1, field2)
+        }
+
+        val emptyForm = flowForm { }
+
+        assertNull(form.field("non-existing-field-id"))
+        assertNull(emptyForm.field("non-existing-field-id"))
+    }
+
     private fun mockkFlowField(
         id : String? = null,
         status: Flow<FieldStatus> = flowOf(FieldStatus()),
@@ -611,6 +636,12 @@ class FlowFormTest {
         every { this@mockk.onBlurValidations } returns allValidationsList
         id?.let { every { this@mockk.id } returns id }
         every { this@mockk.status } returns status
+    }
+
+    companion object {
+        private const val FIELD_ID_1 = "field1"
+        private const val FIELD_ID_2 = "field2"
+        private const val FIELD_ID_3 = "field3"
     }
 
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
@@ -23,9 +23,9 @@ fun getTestDispatcher(testScheduler: TestCoroutineScheduler): TestDispatcher {
 
 fun validation(result : ValidationResult, failFast : Boolean = false, async : Boolean = false)
         = mockk<Validation> {
-    every { async } returns async
+    every { this@mockk.async } returns async
     every { this@mockk.failFast } returns failFast
-    coEvery { validate() } coAnswers { result }
+    coEvery { this@mockk.validate() } coAnswers { result }
 }
 
 fun asyncValidation(delayInMillis : Long, result : ValidationResult, failFast : Boolean = false)

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
@@ -21,9 +21,9 @@ fun getTestDispatcher(testScheduler: TestCoroutineScheduler): TestDispatcher {
     return StandardTestDispatcher(testScheduler, name = TEST_IO_DISPATCHER_NAME)
 }
 
-fun validation(result : ValidationResult, failFast : Boolean = false)
+fun validation(result : ValidationResult, failFast : Boolean = false, async : Boolean = false)
         = mockk<Validation> {
-    every { async } returns false
+    every { async } returns async
     every { this@mockk.failFast } returns failFast
     coEvery { validate() } coAnswers { result }
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/CrossFieldValidationTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/CrossFieldValidationTest.kt
@@ -1,0 +1,30 @@
+package com.rootstrap.flowforms.core.validation
+
+import com.rootstrap.flowforms.core.util.validation
+import io.mockk.coVerify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class CrossFieldValidationTest {
+
+    @Test
+    fun `GIVEN a regular cross field validation WHEN used as is THEN assert it is working as the given validation`()
+    = runTest {
+        val validation = validation(ValidationResult.Correct, failFast = true, async = true)
+        val crossFieldValidation = CrossFieldValidation(
+            validation = validation,
+            targetFieldId = "targetFieldId"
+        )
+
+        assertEquals(validation.failFast, crossFieldValidation.failFast)
+        assertEquals(validation.async, crossFieldValidation.async)
+        assertEquals(ValidationResult.Correct, crossFieldValidation.validate())
+        coVerify(exactly = 1) {
+            validation.validate()
+        }
+    }
+
+}

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/CrossFieldValidationTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/validation/CrossFieldValidationTest.kt
@@ -4,7 +4,7 @@ import com.rootstrap.flowforms.core.util.validation
 import io.mockk.coVerify
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
-import org.junit.Test
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![FlowForms Logo](https://github.com/rootstrap/FlowForms/blob/pages/docs/images/logotype-FlowForms-small-background.png?raw=true)
 
-[![](https://jitpack.io/v/rootstrap/FlowForms.svg)](https://jitpack.io/#rootstrap/FlowForms) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](code_of_conduct.md) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Maintained : Yes!](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/rootstrap/FlowForms/graphs/commit-activity) [![Documentation](https://readthedocs.org/projects/ansicolortags/badge/?version=latest)](https://rootstrap.github.io/FlowForms/) ![Build Status](https://github.com/rootstrap/FlowForms/actions/workflows/gradle.yml/badge.svg)
+[![](https://jitpack.io/v/rootstrap/FlowForms.svg)](https://jitpack.io/#rootstrap/FlowForms) [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT) [![Maintained : Yes!](https://img.shields.io/badge/Maintained%3F-yes-green.svg)](https://github.com/rootstrap/FlowForms/graphs/commit-activity) [![Documentation](https://readthedocs.org/projects/ansicolortags/badge/?version=latest)](https://rootstrap.github.io/FlowForms/) ![Build Status](https://github.com/rootstrap/FlowForms/actions/workflows/gradle.yml/badge.svg)
 
 ### KMP library for form management
 
@@ -23,14 +23,14 @@ class SignUpViewModel {
         )
         field(NEW_PASSWORD,
             Required { formModel.newPassword },
-            MinLength(MIN_PASSWORD_LENGTH) { formModel.newPassword }
+            MinLength(MIN_PASSWORD_LENGTH) { formModel.newPassword },
+            Match { formModel.newPassword to formModel.confirmPassword } on CONFIRM_PASSWORD 
         )
         field(CONFIRM_PASSWORD,
             Required { formModel.confirmPassword },
-            MinLength(MIN_PASSWORD_LENGTH) { formModel.confirmPassword }
-        ) {
-            onBlur(Match { formModel.newPassword to formModel.confirmPassword })
-        }
+            MinLength(MIN_PASSWORD_LENGTH) { formModel.confirmPassword },
+            Match { formModel.newPassword to formModel.confirmPassword }
+        )
         field(CONFIRMATION, RequiredTrue { formModel.confirm.value })
         dispatcher = Dispatchers.IO // your async dispatcher of preference, this one is from Android
     }
@@ -46,7 +46,7 @@ class SignUpViewModel {
 }
 ```
 
-It aims to reduce all the boiler plate needed to work with application forms by allowing the developer to directly declare the form and its fields with their respective validations, allowing to mix both synchronous and asynchronous validations quickly and easily, while also exposing a simple yet powerful API to react to the form and its field status changes under different circumstances.
+It aims to reduce all the boilerplate needed to work with application forms by allowing the developer to directly declare the form and its fields with their respective validations, allowing to mix both synchronous and asynchronous validations quickly and easily, while also exposing a simple yet powerful API to react to the form and its field status changes under different circumstances.
 
 For example, in the above snippet we are declaring the whole sign up form behavior, and now we only need to care about connecting it with our UI, which may  vary per platform and is explained in the "[Excellent! Lets get started](excellent-lets-get-started)" section.
 
@@ -70,10 +70,10 @@ dependencies {
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")
 
-  // On android projects :
+  // On android-only projects :
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core-android:$flowFormsVersion")
 
-  // On JVM projects :
+  // On JVM-only projects :
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core-jvm:$flowFormsVersion")
   ..
 }
@@ -87,10 +87,12 @@ To start creating forms at lightning speed please refer to one of our quickstart
 ## Features
  - Declarative way of creating a form and define its behavior
  - Automatic handling of field and form state, which exposes a reactive api using Kotlin's flows.
- - Easy asynchronous validations using coroutines
- - FailFast validations (configurable)
+ - Separately define OnValueChange, OnFocus, and OnBlur validations.
+ - Easy asynchronous validations powered by coroutines
+ - FailFast validations _(configurable)_
  - Built-in validations so we don't need to write the same logic across projects/modules.
- - Custom validations
+ - Cross-field validations _(with just a keyword!)_
+ - Custom validations with ease
  - UI binding utilities for Android
  - And more!
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,7 +21,7 @@ title: Flow Forms, Declarative and reactive form management library
 FlowForms is a declarative and reactive Kotlin multiplatform library for Form management
 
 ## Why?
-It aims to reduce all the boiler plate needed to work with application forms by allowing the developer to directly declare the form and its fields with their respective validations _(being them synchronous or asynchronous)_, while also exposing a simple yet powerful API to react to the form and field status changes
+It aims to reduce all the boilerplate needed to work with application forms by allowing the developer to directly declare the form and its fields with their respective validations _(being them synchronous or asynchronous)_, while also exposing a simple yet powerful API to react to the form and field status changes
 
 ## Sounds good, how can I get it?
 Add the JitPack repository to your root build.gradle file, at the end of repositories :
@@ -43,10 +43,10 @@ dependencies {
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")
 
-  // On android projects :
+  // On android-only projects :
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core-android:$flowFormsVersion")
 
-  // On JVM projects :
+  // On JVM-only projects :
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core-jvm:$flowFormsVersion")
   ..
 }

--- a/docs/pages/android-quickstart.md
+++ b/docs/pages/android-quickstart.md
@@ -43,11 +43,11 @@ class SignUpFormFragment : Fragment() {
         super.onViewCreated(view, savedInstanceState)
         viewModel = ViewModelProvider(requireActivity())[SignUpViewModel::class.java] // or use you favorite DI tool
         ...
-        viewModel.form.fields.value.let {
+        viewModel.form.apply {
             repeatOnLifeCycleScope(
-                { it[SignUpViewModel.USERNAME]?.status?.collect(::onUserNameStatusChange) },
-                { it[SignUpViewModel.PASSWORD]?.status?.collect(::onPasswordStatusChange) },
-                { viewModel.form.status.collect(::onFormStatusChange) }
+                { field(SignUpViewModel.USERNAME)?.status?.collect(::onUserNameStatusChange) },
+                { field(SignUpViewModel.PASSWORD)?.status?.collect(::onPasswordStatusChange) },
+                { status.collect(::onFormStatusChange) }
             )
         }
     }
@@ -75,8 +75,8 @@ class SignUpFormFragment : Fragment() {
     }
 }
 </code></pre>
-<p class="comment">In the above snippet we are collecting (observing) our fields' status and displaying an error message in their input layouts when the field is incorrect (ie. a field's validation failed). Both REQUIRED_UNSATISFIED and MIN_LENGTH_UNSATISFIED are status codes of the fields' validations.
-Additionally, we are observing the general form status, enabling a "continue" button when the form is correct (ie. all its fields are correct) and disabling it when any of its fields are incorrect (at least one validation failed on some field).</p>
+<p class="comment">In the above snippet we are getting each field using the form.field(...) function, and then collecting (observing) their status and displaying an error message in their input layouts when the field is incorrect (i.e. a field's validation failed). Both REQUIRED_UNSATISFIED and MIN_LENGTH_UNSATISFIED are specific status codes of the defined fields' validations in the form declaration (on the VM).
+Additionally, we are collecting the general form status, enabling a "continue" button when the form is correct (i.e. all its fields are correct) and disabling it when any of its fields are incorrect (at least one validation failed on some field).</p>
 
 **3 :** Bind your input views to the form fields using our bind form's extension function : 
 
@@ -101,8 +101,8 @@ This quickstart example is also meant to be used with two-way databinding, setti
 <pre><code class="xml">
 android:text="@={viewModel.userName}"
 </code></pre>
-For further information about two-way databiding, refer to [this official documentation](https://developer.android.com/topic/libraries/data-binding/two-way). However, the snippets above can be easily adapted to avoid using two-way databinding.
+For further information about two-way databiding, refer to [this official documentation](https://developer.android.com/topic/libraries/data-binding/two-way). However, the snippets above can be easily adapted to not use two-way databinding.
 
 **FlowForms**'s full potential is better appreciated when making more complex forms, you can review the [android example app ViewModel](https://github.com/rootstrap/FlowForms/blob/main/ExampleApp%20Android/src/main/java/com/rootstrap/flowforms/example/SignUpViewModel.kt) included in the project. Which makes use of asynchronous validations and many other capabilities. You will see that the implementation steps doesn't change at all. BTW, there is an example using Activity and another one using Fragment.
 
-However, the example app and this guide does not cover all **FlowForms**'s features, so for a detailed list of all the available features please refer to the [documentation index](documentation-index)
+However, the example app and this guide does not cover all **FlowForms**'s features (but a lot of them), so for a detailed list of all the available features please refer to the [documentation index](documentation-index)

--- a/docs/pages/android-utils/Binding.md
+++ b/docs/pages/android-utils/Binding.md
@@ -9,7 +9,7 @@ At a glance, to trigger the Form's field validations we need to call its trigger
 
 ### View to FlowField binding 
 
-Well, for android projects we have a `FlowForm.bind(...)` extension method that helps us reduce that boiler plate. In this case this "bind" function allow us to bind a field in our FlowForm to a View in the UI, which will automatically take care of triggering the FlowForm's `onValueChange`, `onFocus`, and `onBlur` validations for each field we specify when such events occur.
+Well, for android projects we have a `FlowForm.bind(...)` extension method that helps us reduce that boilerplate. In this case this "bind" function allow us to bind a field in our FlowForm to a View in the UI, which will automatically take care of triggering the FlowForm's `onValueChange`, `onFocus`, and `onBlur` validations for each field we specify when such events occur.
 
 <pre><code class="kotlin">
 private fun bindFields() {
@@ -36,7 +36,7 @@ At the moment, for automatic View to FlowField binding we support the following 
 
 Trying to use an unsupported View type will result in `IllegalArgumentException`.
 
-<div class="rs-row comment"> <i class="comment-icon fa-solid fa-circle-info"></i> <div class="comment">We will be adding more View types in the future, please feel free to raise an issue with your use case if you don't find the View you are using in the above list.</div> </div>
+<div class="rs-row comment"> <i class="comment-icon fa-solid fa-circle-info"></i> <div class="comment">Please feel free to raise an issue with your use case if you don't find the View you are using in the above list and we will be glad to add it in a future release.</div> </div>
 
 ### LiveData to FlowField binding 
 
@@ -61,7 +61,7 @@ In this case, whenever the specified LiveData's value change the indicated field
 
 ### Why do we need to pass lifecycleScope when using the bind extensions?
 
-The bind methods require to pass the `lifecycleScope` as argument because the validate functions in the FlowForm are `suspending functions`, hence they need to be called from a `coroutine`, and using the `lifecycleScope` gives us the benefit that anything we called will be immediatelly cancelled if the `lifecycleScope` is `cancelled/destroyed`. 
+The bind methods require to pass the `lifecycleScope` as argument because the validate functions in the FlowForm are `suspending functions`, hence they need to be called from a `coroutine`, and using the `lifecycleScope` gives us the benefit that anything we called will be immediately cancelled if the `lifecycleScope` is `cancelled/destroyed`. 
 
 In the case of binding a `LiveData` to a `FlowField`, we also need to pass a `LifecycleOwner` to be able to listen to the `LiveData` changes only when the fragment's/activity's lifecycle is on an active state (`started` or `resumed`). basically we call the `LiveData.observe(...)` method using the given `LifecycleOwner`.
 

--- a/docs/pages/core/FlowForm.md
+++ b/docs/pages/core/FlowForm.md
@@ -73,11 +73,9 @@ val coroutineScope: CoroutineScope = ...
 
 suspend fun listenToFieldsStatus() {
     coroutineScope {
-        form.fields.value.let {
-            launch { it["userName"]?.status?.collect(::onUserNameStatusChange) }
-            launch { it["email"]?.status?.collect(::onEmailStatusChange) }
-            launch { it["password"]?.status?.collect(::onPasswordStatusChange) }
-        }
+        launch { form.field("userName")?.status?.collect(::onUserNameStatusChange) }
+        launch { form.field("email")?.status?.collect(::onEmailStatusChange) }
+        launch { form.field("password")?.status?.collect(::onPasswordStatusChange) }
     }
 }
 
@@ -99,7 +97,8 @@ private fun onPasswordStatusChange(status: FieldStatus) {
     }
 }
 </code></pre>
-<p class="comment">In the above code snippet we are declaring a collection function for each field that will be executed whenever the specified field status changes.</p>
+<p class="comment">In the above code snippet we are declaring a collection function for each field that will be executed whenever the specified field status changes.<br>
+Notice that we call the field(...) function to get each field from the form</p>
 
 This way we can react to each field status change and do our custom logic for any case. For more information about the fields possible status check the [Field state section](FlowField#field-state)
 
@@ -114,6 +113,13 @@ Basically, the form status changes automatically based on its fields status, so 
 So, the only thing we need to do, is just to call the form's triggerValidations method with the specific field ID we are validating when we need to. 
 For example, everytime the password input is updated by the user, we just trigger the **password field validations**
 
+<div class="rs-row comment"> 
+    <i class="comment-icon fa-solid fa-circle-info"></i> 
+    <div class="comment">
+        If using <b>Android's xml UI</b>, all the code below is simplified as a one-liner for some View types. To take a look please refer to the <a href="../android-utils/Binding">Android binding page</a>
+    </div>
+</div>
+    
 <pre><code class="kotlin">
 val form = ...
 val coroutineScope: CoroutineScope = ...
@@ -121,20 +127,20 @@ val passwordInput = ...
 
 fun triggerValidationsWhenInputIsUpdated() {
     passwordInput.doAfterTextChanged {
-        coroutineScope.launch { validateOnValueChange(fieldId) }
+        coroutineScope.launch { form.validateOnValueChange("password") }
     }
     passwordInput.doOnBlur {
-        coroutineScope.launch { validateOnBlur(fieldId) }
+        coroutineScope.launch { form.validateOnBlur("password") }
     }
     passwordInput.doOnFocus {
-        coroutineScope.launch { validateOnFocus(fieldId) }
+        coroutineScope.launch { form.validateOnFocus("password") }
     }
 }
 </code></pre>
-<p class="comment">In the above code snippet we are triggering the validations for the password field whenever its value changes (input value was updated), it gains focus (onFocus) and when it loses the focus (onBlur). <br>
+<p class="comment">In the above code snippet we are triggering the validations for the password field whenever its value changes (input value was updated), when it gains focus (onFocus) and when it loses the focus (onBlur). <br>
 Here passwordInput represents an input in your UI library, so it may change based on the library you use. We also provide some binding utilities fot specific platforms. The current example is fictitious so it is not based in any existing library</p>
 
-This will automatically trigger any of the password field's validations, which will then update the field's status based on their results, which will also automatically update the form's status.
+This will automatically trigger the password field's validations defined for each case, which will then update the field's status based on their results, which will also automatically update the form's status.
 
 Actually, there are 3 types of validations : 
 
@@ -143,5 +149,3 @@ Actually, there are 3 types of validations :
  * OnBlur validations
 
 To learn more about the validations please refer to the [Adding validations to a field section](FlowField#adding-validations-to-a-field).
-
-If using **Android's UI**, we made a bunch of utilities to reduce even more the code needed for this. To take a look at it please refer to the [Android binding page](../android-utils/Binding)

--- a/docs/pages/core/Validation.md
+++ b/docs/pages/core/Validation.md
@@ -53,7 +53,7 @@ If the validation is not fulfilled and `failFast` is false, then the field's val
 
 ## Async validations
 
-One of the goals of FlowForms is to run validations asynchronously as easy as possible. And to do that, we only to set the `async` property as true when creating a Validation object.
+One of the goals of FlowForms is to run validations asynchronously as easy as possible. And to do that, we only need to set the `async` property as true when creating a Validation object.
 
 <pre><code class="kotlin">
 var userName = ""
@@ -77,6 +77,38 @@ When an async validation is about to start, the field's status is updated with t
 Whenever we **re-trigger** the field's validations, all current async validations will be cancelled automatically to avoid wasting unnecesaary resources, and a new and fresh field validation process will be started.
 
 <div class="rs-row comment"> <i class="comment-icon fa-solid fa-circle-info"></i> <div class="comment"> async is false by default on all Validations </div> </div>
+
+## Cross-field validations
+
+By using the `on` keyword on a Validation we can declare a cross-field validation. Basically, a cross-field validation is a regular validation whose result will affect the specified field instead of the current one _(which triggered the validation)_
+
+<pre><code class="kotlin">
+var password = ""
+var confirmPassword = ""
+
+val form = flowForm {
+    field(PASSWORD,
+        Match { password to confirmPassword } on CONFIRM_PASSWORD
+    )
+    field(CONFIRM_PASSWORD,
+        Match { password to confirmPassword }
+    )
+}
+</code></pre>
+<p class="comment">Declaring a Match validation on the PASSWORD field that will affect the status of the CONFIRM_PASSWORD field</p>
+
+For example, in the above code, everytime the PASSWORD field is validated, it will trigger the Match validation, but its result will affect the CONFIRM_PASSWORD field instead of the PASSWORD field.
+
+This is really useful for use cases like this one, because anytime the PASSWORD or the CONFIRM_PASSWORD fields changes the Match validation will be executed and the respective incorrect status will be applied only to one of the fields _(in this case, the CONFIRM_PASSWORD)_ 
+
+ 
+We can have as many cross-field validations as we want affecting a specific field, or even affecting different fields.
+
+The cross-field validations doesn't trigger the regular field validations of the target field, they work as a separate set of validations. In addition to that, the cross-field validations are not triggered if the target field is in the UNMODIFIED status To avoid preemptive failure.
+
+<div class="rs-row comment"> <i class="comment-icon fa-solid fa-circle-info"></i> <div class="comment">
+All the rules of the regular validations applies, they can be or not be asynchronous, failFast or not, etc.
+</div> </div>
 
 ## Custom validations
 
@@ -119,7 +151,7 @@ If you want to modify how the validation behavior process works you can create y
 <pre><code class="kotlin">
 var userName = ""
 val form = flowForm {
-    field("username", Required { userName } ) {
+    field("username", Required { userName }) {
         validationBehavior = MyCustomValidationBehavior()
     }
 }

--- a/docs/pages/documentation-index.md
+++ b/docs/pages/documentation-index.md
@@ -28,6 +28,7 @@ title: FlowForms docs - index
  * [Fail Fast validations](core/Validation#failfast-validations)
  * [Async validations](core/Validation#async-validations)
  * [Built-in validations](core/Validation#built-in-validations)
+ * [Cross-field validations](core/Validation#cross-field-validations)
  * [Custom validations](core/Validation#custom-validations)
  * [Changing the field's validation behavior](core/Validation#changing-the-fields-validation-behavior)
 


### PR DESCRIPTION
#### ISSUE[#20] 
* Continuation of https://github.com/rootstrap/FlowForms/pull/45 

---

#### Description
* Added the `field(...)` method to get fields directly from the form without needing to access the internals of the fields flow. 
* implemented unit tests for the new `cross-field validations` feature and `field(...)` function

---

#### Notes
 * Feature documentation will be added on next PR.

---

#### Preview

This is the test coverage report. For some reason it is considering the test classes too so the "branch" coverage column does not reflect the real coverage, which is higher.
<img width="1280" alt="image" src="https://user-images.githubusercontent.com/26490822/219447688-f0c88704-1e90-48ff-9c13-35bd8a199f27.png">
