### PR TITLE
Update gradle to 7.4.1, Kotlin to 1.8.10 and lib version to 1.3.0

### DIFF
--- a/ExampleApp Android/build.gradle.kts
+++ b/ExampleApp Android/build.gradle.kts
@@ -12,7 +12,7 @@ android {
         minSdk = (ExampleAppAndroidConfig.MIN_SDK)
         targetSdk = (ExampleAppAndroidConfig.TARGET_SDK)
         versionCode = 1
-        versionName = "1.2.0"
+        versionName = "1.3.0"
 
         testInstrumentationRunner = ExampleAppAndroidConfig.ANDROID_TEST_INSTRUMENTATION_RUNNER
     }

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.rootstrap"
-version = "1.2.0"
+version = "1.3.0"
 
 kotlin {
     android {

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Based on your project, add FlowForms dependency in your module's build.gradle fi
 ```kotlin
 dependencies {
   ..
-  val flowFormsVersion = "1.2.0"
+  val flowFormsVersion = "1.3.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -3,8 +3,8 @@
 object Versions {
 
     //app level
-    const val GRADLE = "7.1.3"
-    const val KOTLIN = "1.6.0"
+    const val GRADLE = "7.4.1"
+    const val KOTLIN = "1.8.10"
 
     //libs
     const val CORE_KTX = "1.7.0"

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Add FlowForms dependency in your module's build.gradle file :
 <pre><code class="kotlin">
 dependencies {
   ..
-  val flowFormsVersion = "1.2.0"
+  val flowFormsVersion = "1.3.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,6 +15,7 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
+android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 23 17:33:30 ART 2022
+#Thu Mar 16 13:49:58 EDT 2023
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
#### ISSUE[#51]
* closes #51 

---

#### Description
* Upgraded gradle to 7.4.1
* Upgraded Kotlin to 1.8.10
* Upgraded version to 1.3.0 since this is not a bugfix and cannot be used on projects using the previous gradle release.
* Enabled jetifier on Android example app since some of its dependencies still uses support libraries
