### PR TITLE
Add related fieldId to FieldStatus entity

### DIFF
--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldStatus.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldStatus.kt
@@ -12,11 +12,13 @@ import com.rootstrap.flowforms.core.validation.ValidationResult
  *
  * By default every fieldStatus starts at [UNMODIFIED]
  *
+ * @param fieldId The field's ID of this status' field.
  * @param code The status of the field. Being it [UNMODIFIED], [INCOMPLETE], [CORRECT],
  * [INCORRECT], [IN_PROGRESS] or a custom error code
  * @param validationResults The list of validations with their results, triggered to reach this status.
  */
 data class FieldStatus(
     val code : String = UNMODIFIED,
+    val fieldId: String,
     val validationResults : List<ValidationResult> = emptyList()
 )

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldValidationBehavior.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldValidationBehavior.kt
@@ -16,11 +16,36 @@ interface FieldValidationBehavior {
      * How they are triggered and behave depends on the implementation.
      *
      * Must return a boolean indicating if all the validations were successful or not.
+     *
+     * @param fieldId The ID of the field being validated.
+     * @param mutableFieldStatus a mutable stateFlow to notify the status updates of the field during the validations.
+     * @param validations The validations to trigger.
+     * @param asyncCoroutineDispatcher The coroutine dispatcher to use for asynchronous validations.
      */
     suspend fun triggerValidations(
+        fieldId : String,
         mutableFieldStatus: MutableStateFlow<FieldStatus>,
         validations: List<Validation>,
         asyncCoroutineDispatcher: CoroutineDispatcher? = null
     ) : Boolean
+
+    /**
+     * Trigger the given validations firing updates to the mutable field status.
+     * How they are triggered and behave depends on the implementation.
+     *
+     * Must return a boolean indicating if all the validations were successful or not.
+     * @param mutableFieldStatus a mutable stateFlow to notify the status updates of the field during the validations.
+     * @param validations The validations to trigger.
+     * @param asyncCoroutineDispatcher The coroutine dispatcher to use for asynchronous validations.
+     */
+    @Deprecated(
+        message = "Deprecated since it does not use the field ID. Will be removed on future versions",
+        replaceWith = ReplaceWith("triggerValidations(fieldId, mutableFieldStatus, validations, asyncCoroutineDispatcher)")
+    )
+    suspend fun triggerValidations(
+        mutableFieldStatus: MutableStateFlow<FieldStatus>,
+        validations: List<Validation>,
+        asyncCoroutineDispatcher: CoroutineDispatcher? = null
+    ) : Boolean { return true }
 
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehaviorTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehaviorTest.kt
@@ -29,12 +29,15 @@ class DefaultFieldValidationBehaviorTest {
     fun `GIVEN a validation WHEN it is correct THEN assert the field status is CORRECT`()
     = runTest {
         val correctValidation = validation(ValidationResult.Correct)
-        val field = FlowField("email", listOf(correctValidation))
+        val field = FlowField(id = FIELD_ID, listOf(correctValidation))
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerOnValueChangeValidations()
-            assertEquals(CORRECT, awaitItem().code)
+            awaitItem().run {
+                assertEquals(FIELD_ID, fieldId)
+                assertEquals(CORRECT, code)
+            }
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -44,12 +47,15 @@ class DefaultFieldValidationBehaviorTest {
     = runTest {
         val customErrorCode = "custom-code"
         val failingValidation = validation(ValidationResult(customErrorCode))
-        val field = FlowField("email", listOf( failingValidation ) )
+        val field = FlowField(id = FIELD_ID, listOf( failingValidation ) )
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerOnValueChangeValidations()
-            assertEquals(customErrorCode, awaitItem().code)
+            awaitItem().run {
+                assertEquals(FIELD_ID, fieldId)
+                assertEquals(customErrorCode, code)
+            }
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -60,12 +66,15 @@ class DefaultFieldValidationBehaviorTest {
         val customErrorCode = "Custom-code"
         val correctValidation = validation(ValidationResult.Correct)
         val failingValidation = validation(ValidationResult(customErrorCode))
-        val field = FlowField("email", listOf(correctValidation, failingValidation))
+        val field = FlowField(id = FIELD_ID, listOf(correctValidation, failingValidation))
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerOnValueChangeValidations()
-            assertEquals(customErrorCode, awaitItem().code)
+            awaitItem().run {
+                assertEquals(FIELD_ID, fieldId)
+                assertEquals(customErrorCode, code)
+            }
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -75,12 +84,15 @@ class DefaultFieldValidationBehaviorTest {
     = runTest {
         val correctValidation = validation(ValidationResult.Correct)
         val failingValidation = validation(ValidationResult.Incorrect)
-        val field = FlowField("email", listOf(failingValidation, correctValidation))
+        val field = FlowField(id = FIELD_ID, listOf(failingValidation, correctValidation))
 
         field.status.test {
             awaitItem() // UNMODIFIED status
             field.triggerOnValueChangeValidations()
-            assertEquals(INCORRECT, awaitItem().code)
+            awaitItem().run {
+                assertEquals(FIELD_ID, fieldId)
+                assertEquals(INCORRECT, code)
+            }
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -90,7 +102,7 @@ class DefaultFieldValidationBehaviorTest {
     = runTest {
         val failingValidation = validation(ValidationResult.Incorrect, true)
         val correctValidation = validation(ValidationResult.Correct)
-        val field = FlowField("email", listOf(failingValidation, correctValidation))
+        val field = FlowField(id = FIELD_ID, listOf(failingValidation, correctValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations()
@@ -107,7 +119,7 @@ class DefaultFieldValidationBehaviorTest {
     fun `GIVEN a field with an async validation but without a coroutine dispatcher THEN assert it throws IllegalStateException`()
     = runTest {
         val asyncValidation = asyncValidation(0, ValidationResult.Correct)
-        val field = FlowField("email", listOf(asyncValidation))
+        val field = FlowField(id = FIELD_ID, listOf(asyncValidation))
 
         val exception = assertFails { field.triggerOnValueChangeValidations() }
         assertIs<IllegalStateException>(exception)
@@ -118,11 +130,11 @@ class DefaultFieldValidationBehaviorTest {
     = runTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val correctAsyncValidation = asyncValidation(0, ValidationResult.Correct)
-        val field = FlowField("email", listOf(correctAsyncValidation))
+        val field = FlowField(id = FIELD_ID, listOf(correctAsyncValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, CORRECT)
+            assertFieldStatusSequence(fieldId = FIELD_ID, this, UNMODIFIED, IN_PROGRESS, CORRECT)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -132,11 +144,11 @@ class DefaultFieldValidationBehaviorTest {
     = runTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val incorrectAsyncValidation = asyncValidation(0, ValidationResult.Incorrect)
-        val field = FlowField("email", listOf(incorrectAsyncValidation))
+        val field = FlowField(id = FIELD_ID, listOf(incorrectAsyncValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
+            assertFieldStatusSequence(fieldId = FIELD_ID, this, UNMODIFIED, IN_PROGRESS, INCORRECT)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -148,11 +160,11 @@ class DefaultFieldValidationBehaviorTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val correctAsyncValidation = asyncValidation(0, ValidationResult.Correct)
         val incorrectAsyncValidation = asyncValidation(0, ValidationResult(customErrorCode))
-        val field = FlowField("email", listOf(correctAsyncValidation, incorrectAsyncValidation))
+        val field = FlowField(id = FIELD_ID, listOf(correctAsyncValidation, incorrectAsyncValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, customErrorCode)
+            assertFieldStatusSequence(fieldId = FIELD_ID, this, UNMODIFIED, IN_PROGRESS, customErrorCode)
             cancelAndIgnoreRemainingEvents()
         }
     }
@@ -164,12 +176,12 @@ class DefaultFieldValidationBehaviorTest {
         val fastestVal = asyncValidation(10, ValidationResult.Correct)
         val middleIncorrectVal = asyncValidation(20, ValidationResult.Incorrect, true)
         val slowerVal = asyncValidation(30, ValidationResult.Correct)
-        val field = FlowField("email", listOf(slowerVal, fastestVal, middleIncorrectVal))
+        val field = FlowField(id = FIELD_ID, listOf(slowerVal, fastestVal, middleIncorrectVal))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
 
-            val lastStatus = assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
+            val lastStatus = assertFieldStatusSequence(fieldId = FIELD_ID, this, UNMODIFIED, IN_PROGRESS, INCORRECT)
             // checks that the slower validation was not added to the results (because it was cancelled before)
             assertEquals(2, lastStatus.validationResults.size)
             cancelAndIgnoreRemainingEvents()
@@ -183,11 +195,11 @@ class DefaultFieldValidationBehaviorTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val regularValidation = validation(ValidationResult.Correct)
         val asyncValidation = asyncValidation(10, ValidationResult.Correct)
-        val field = FlowField("email", listOf(regularValidation, asyncValidation))
+        val field = FlowField(id = FIELD_ID, listOf(regularValidation, asyncValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, CORRECT)
+            assertFieldStatusSequence(FIELD_ID, this, UNMODIFIED, IN_PROGRESS, CORRECT)
 
             coVerify(exactly = 1) { regularValidation.validate() }
             coVerify(exactly = 1) { asyncValidation.validate() }
@@ -202,11 +214,11 @@ class DefaultFieldValidationBehaviorTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val regularValidation = validation(ValidationResult.Incorrect, true)
         val asyncValidation = asyncValidation(10, ValidationResult.Correct)
-        val field = FlowField("email", listOf(regularValidation, asyncValidation))
+        val field = FlowField(FIELD_ID, listOf(regularValidation, asyncValidation))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            assertFieldStatusSequence(this, UNMODIFIED, INCORRECT)
+            assertFieldStatusSequence(FIELD_ID, this, UNMODIFIED, INCORRECT)
 
             coVerify(exactly = 1) { regularValidation.validate() }
             coVerify(exactly = 0) { asyncValidation.validate() }
@@ -223,11 +235,11 @@ class DefaultFieldValidationBehaviorTest {
         val testAsyncCoroutineDispatcher = getTestDispatcher(testScheduler)
         val asyncValidation = asyncValidation(5, ValidationResult(customErrorCode1))
         val asyncValidation2 = asyncValidation(5, ValidationResult(customErrorCode2))
-        val field = FlowField("email", listOf(asyncValidation, asyncValidation2))
+        val field = FlowField(FIELD_ID, listOf(asyncValidation, asyncValidation2))
 
         field.status.test {
             field.triggerOnValueChangeValidations(testAsyncCoroutineDispatcher)
-            val lastStatusResults = assertFieldStatusSequence(this, UNMODIFIED, IN_PROGRESS, INCORRECT)
+            val lastStatusResults = assertFieldStatusSequence(FIELD_ID, this, UNMODIFIED, IN_PROGRESS, INCORRECT)
                 .validationResults
 
             coVerify(exactly = 1) { asyncValidation.validate() }
@@ -247,7 +259,7 @@ class DefaultFieldValidationBehaviorTest {
     fun `GIVEN the same validation in OnValueChange, OnBlur, and OnFocus Validations, THEN assert it was called 3 times`()
             = runTest {
         val validation = validation(ValidationResult.Correct)
-        val field = FlowField("email",
+        val field = FlowField(FIELD_ID,
             onValueChangeValidations = listOf(validation),
             onBlurValidations = listOf(validation),
             onFocusValidations = listOf(validation)
@@ -267,7 +279,7 @@ class DefaultFieldValidationBehaviorTest {
     fun `GIVEN the same correct validation in OnValueChange, OnBlur, and OnFocus Validations, THEN assert the field status changes from UNMODIFIED to INCOMPLETE to CORRECT`()
             = runTest {
         val validation = validation(ValidationResult.Correct)
-        val field = FlowField("email",
+        val field = FlowField(FIELD_ID,
             onValueChangeValidations = listOf(validation),
             onBlurValidations = listOf(validation),
             onFocusValidations = listOf(validation)
@@ -291,6 +303,10 @@ class DefaultFieldValidationBehaviorTest {
 
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    companion object {
+        private const val FIELD_ID = "fieldId"
     }
 
 }

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
@@ -56,9 +56,9 @@ class FlowFormTest {
         val field2 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus())
+        every { field1.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_1))
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus())
+        every { field2.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_2))
 
         flowForm {
             fields(field1, field2)
@@ -75,9 +75,12 @@ class FlowFormTest {
         val field2 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus(), FieldStatus(INCORRECT))
+        every { field1.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1, code = INCORRECT)
+        )
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus())
+        every { field2.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_2))
 
         flowForm {
             fields(field1, field2)
@@ -95,9 +98,12 @@ class FlowFormTest {
         val field2 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus())
+        every { field1.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_1))
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field2.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_2, code = CORRECT)
+        )
 
         flowForm {
             fields(field1, field2)
@@ -115,9 +121,15 @@ class FlowFormTest {
         val field2 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field1.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1, code = CORRECT)
+        )
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field2.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_1, code = CORRECT)
+        )
 
         flowForm {
             fields(field1, field2)
@@ -136,13 +148,20 @@ class FlowFormTest {
         val field3 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
+        every { field1.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1, code = CORRECT)
+        )
 
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field2.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_2, code = CORRECT)
+        )
 
         every { field3.id } returns FIELD_ID_3
-        every { field3.status } returns flowOf(FieldStatus())
+        every { field3.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_3))
 
         flowForm {
             fields(field1, field2, field3)
@@ -162,13 +181,20 @@ class FlowFormTest {
         val field3 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(INCORRECT))
+        every { field1.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1, code = INCORRECT)
+        )
 
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field2.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_2, code = CORRECT)
+        )
 
         every { field3.id } returns FIELD_ID_3
-        every { field3.status } returns flowOf(FieldStatus())
+        every { field3.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_3))
 
         flowForm {
             fields(field1, field2, field3)
@@ -188,13 +214,25 @@ class FlowFormTest {
         val field3 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus(), FieldStatus(CORRECT))
+        every { field1.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_1),
+            FieldStatus(fieldId = FIELD_ID_1, code = CORRECT)
+        )
 
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
+        every { field2.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_2),
+            FieldStatus(fieldId = FIELD_ID_2, code = CORRECT)
+        )
 
         every { field3.id } returns FIELD_ID_3
-        every { field3.status } returns flowOf(FieldStatus(), FieldStatus(), FieldStatus(), FieldStatus(CORRECT))
+        every { field3.status } returns flowOf(
+            FieldStatus(fieldId = FIELD_ID_3),
+            FieldStatus(fieldId = FIELD_ID_3),
+            FieldStatus(fieldId = FIELD_ID_3),
+            FieldStatus(fieldId = FIELD_ID_3, code = CORRECT)
+        )
 
         flowForm {
             fields(field1, field2, field3)
@@ -317,13 +355,13 @@ class FlowFormTest {
         val field2 = mockk<FlowField>()
 
         every { field1.id } returns FIELD_ID_1
-        every { field1.status } returns flowOf(FieldStatus())
+        every { field1.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_1))
         coEvery { field1.triggerOnValueChangeValidations(coroutineDispatcher) } returns false
         coEvery { field1.triggerOnFocusValidations(coroutineDispatcher) } returns true
         coEvery { field1.triggerOnBlurValidations(coroutineDispatcher) } returns true
 
         every { field2.id } returns FIELD_ID_2
-        every { field2.status } returns flowOf(FieldStatus())
+        every { field2.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_2))
         coEvery { field2.triggerOnValueChangeValidations(coroutineDispatcher) } returns false
         coEvery { field2.triggerOnFocusValidations(coroutineDispatcher) } returns true
         coEvery { field2.triggerOnBlurValidations(coroutineDispatcher) } returns true
@@ -409,13 +447,13 @@ class FlowFormTest {
         coEvery { field2.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field2.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field2.triggerOnBlurValidations(any(), any()) } returns true
-        every { field2.getCurrentStatus() } returns FieldStatus(CORRECT)
+        every { field2.getCurrentStatus() } returns FieldStatus(fieldId = FIELD_ID_2, code = CORRECT)
 
         val field3 = mockkFlowField(FIELD_ID_3)
         coEvery { field3.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field3.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field3.triggerOnBlurValidations(any(), any()) } returns true
-        every { field3.getCurrentStatus() } returns FieldStatus(INCORRECT)
+        every { field3.getCurrentStatus() } returns FieldStatus(fieldId = FIELD_ID_3, code = INCORRECT)
 
         val form = flowForm {
             fields(field1, field2, field3)
@@ -479,7 +517,7 @@ class FlowFormTest {
         coEvery { field2.triggerOnValueChangeValidations(any(), any()) } returns true
         coEvery { field2.triggerOnFocusValidations(any(), any()) } returns true
         coEvery { field2.triggerOnBlurValidations(any(), any()) } returns true
-        every { field2.getCurrentStatus() } returns FieldStatus(UNMODIFIED)
+        every { field2.getCurrentStatus() } returns FieldStatus(fieldId = FIELD_ID_2, code = UNMODIFIED)
 
         val form = flowForm {
             fields(field1, field2)
@@ -636,7 +674,7 @@ class FlowFormTest {
 
     private fun mockkFlowField(
         id : String? = null,
-        status: Flow<FieldStatus> = flowOf(FieldStatus()),
+        status: Flow<FieldStatus> = flowOf(FieldStatus(fieldId = id.orEmpty())),
         allValidationsList : List<Validation> = emptyList()
     ) = mockk<FlowField> {
         every { this@mockk.onValueChangeValidations } returns allValidationsList

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/util/Utils.kt
@@ -38,10 +38,11 @@ fun asyncValidation(delayInMillis : Long, result : ValidationResult, failFast : 
     }
 }
 
-suspend fun assertFieldStatusSequence(flowTurbine: FlowTurbine<FieldStatus>, vararg statuses: String): FieldStatus {
+suspend fun assertFieldStatusSequence(fieldId: String, flowTurbine: FlowTurbine<FieldStatus>, vararg statuses: String): FieldStatus {
     var lastValue : FieldStatus? = null
     statuses.forEach {
         lastValue = flowTurbine.awaitItem()
+        assertEquals(fieldId, lastValue?.fieldId)
         assertEquals(it, lastValue?.code)
     }
     return lastValue!!


### PR DESCRIPTION
Please remember to add the proper labels to the PR. You can delete
the template sections that don't apply to this PR. Remove this message.

#### ISSUE[#53]
* closes #53 

---

#### Description
* Added fieldId to FieldStatus entity as required val, as second parameter (so we don't introduce a bug to current code).
* This is useful for reusing collection code.
* Modified the tests to include and verify it.
