### PR TITLE
Emit repeated field status to observers. Remove android Jetifier

### DIFF
--- a/ExampleApp Android/build.gradle.kts
+++ b/ExampleApp Android/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("com.android.application")
+    id("kotlin-kapt")
     kotlin("android")
 }
 
@@ -33,8 +34,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     kotlinOptions {
@@ -52,6 +53,7 @@ dependencies {
     implementation(fileTree(mapOf("dir" to "libs", "include" to listOf("*.jar"))))
     //app libs
     implementation(Dependencies.appLibraries)
+    kapt(Dependencies.appKaptLibraries)
     //test libs
     testImplementation(Dependencies.jvmTestLibraries)
     androidTestImplementation(Dependencies.androidTestLibraries)

--- a/ExampleApp Android/build.gradle.kts
+++ b/ExampleApp Android/build.gradle.kts
@@ -13,7 +13,7 @@ android {
         minSdk = (ExampleAppAndroidConfig.MIN_SDK)
         targetSdk = (ExampleAppAndroidConfig.TARGET_SDK)
         versionCode = 1
-        versionName = "1.3.0"
+        versionName = "1.4.0"
 
         testInstrumentationRunner = ExampleAppAndroidConfig.ANDROID_TEST_INSTRUMENTATION_RUNNER
     }

--- a/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
+++ b/ExampleApp Android/src/main/java/com/rootstrap/flowforms/example/SignUpFormFragment.kt
@@ -110,13 +110,19 @@ class SignUpFormFragment : Fragment() {
         binding?.apply {
             emailLoadingProgressBar.visibility = View.GONE
             emailAvailableText.visibility = View.GONE
-            emailInputLayout.error = null
             when (status.code) {
                 REQUIRED_UNSATISFIED -> emailInputLayout.error = getString(R.string.required_field)
                 BASIC_EMAIL_FORMAT_UNSATISFIED -> emailInputLayout.error = getString(R.string.invalid_email)
                 EMAIL_ALREADY_EXISTS -> emailInputLayout.error = getString(R.string.email_already_exist)
-                IN_PROGRESS -> emailLoadingProgressBar.visibility = View.VISIBLE
-                CORRECT -> emailAvailableText.visibility = View.VISIBLE
+                IN_PROGRESS -> {
+                    emailLoadingProgressBar.visibility = View.VISIBLE
+                    emailInputLayout.error = null
+                }
+                CORRECT -> {
+                    emailAvailableText.visibility = View.VISIBLE
+                    emailInputLayout.error = null
+                }
+                else -> emailInputLayout.error = null
             }
         }
     }

--- a/FlowForms-Core/build.gradle.kts
+++ b/FlowForms-Core/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 }
 
 group = "com.rootstrap"
-version = "1.3.0"
+version = "1.4.0"
 
 kotlin {
     android {
@@ -52,11 +52,10 @@ tasks.koverMergedHtmlReport {
 }
 
 android {
-    compileSdk = 32
+    compileSdk = 33
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     defaultConfig {
         minSdk = 23
-        targetSdk = 32
     }
 
     buildTypes {

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehavior.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/DefaultFieldValidationBehavior.kt
@@ -9,7 +9,7 @@ import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.yield
 
 /**
@@ -31,7 +31,7 @@ class DefaultFieldValidationBehavior : FieldValidationBehavior {
      */
     override suspend fun triggerValidations(
         fieldId : String,
-        mutableFieldStatus: MutableStateFlow<FieldStatus>,
+        mutableFieldStatus: MutableSharedFlow<FieldStatus>,
         validations: List<Validation>,
         asyncCoroutineDispatcher: CoroutineDispatcher?
     ) : Boolean {
@@ -141,13 +141,13 @@ class DefaultFieldValidationBehavior : FieldValidationBehavior {
         }
 
         yield()
-        data.mutableFieldStatus.value = fieldStatus
+        data.mutableFieldStatus.emit(fieldStatus)
         return fieldStatus.code == StatusCodes.CORRECT
     }
 
     private class ValidationProcessData(
         val fieldId : String,
-        val mutableFieldStatus: MutableStateFlow<FieldStatus>,
+        val mutableFieldStatus: MutableSharedFlow<FieldStatus>,
         val syncValidations : List<Validation>,
         val asyncValidations : List<Validation>,
         val asyncCoroutineDispatcher: CoroutineDispatcher?,

--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldValidationBehavior.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/field/FieldValidationBehavior.kt
@@ -2,6 +2,7 @@ package com.rootstrap.flowforms.core.field
 
 import com.rootstrap.flowforms.core.validation.Validation
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 
 /**
@@ -24,7 +25,7 @@ interface FieldValidationBehavior {
      */
     suspend fun triggerValidations(
         fieldId : String,
-        mutableFieldStatus: MutableStateFlow<FieldStatus>,
+        mutableFieldStatus: MutableSharedFlow<FieldStatus>,
         validations: List<Validation>,
         asyncCoroutineDispatcher: CoroutineDispatcher? = null
     ) : Boolean

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ Based on your project, add FlowForms dependency in your module's build.gradle fi
 ```kotlin
 dependencies {
   ..
-  val flowFormsVersion = "1.3.0"
+  val flowFormsVersion = "1.4.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/buildSrc/src/main/java/Dependencies.kt
+++ b/buildSrc/src/main/java/Dependencies.kt
@@ -11,8 +11,7 @@ object Dependencies {
     private const val CORE_KTX = "androidx.core:core-ktx:${Versions.CORE_KTX}"
     private const val MATERIAL = "com.google.android.material:material:${Versions.MATERIAL}"
     private const val CONSTRAINT_LAYOUT = "androidx.constraintlayout:constraintlayout:${Versions.CONSTRAINT_LAYOUT}"
-    private const val LIFECYCLE_COMMON = "android.arch.lifecycle:common-java8:${Versions.LIFECYCLE_COMMON}"
-    private const val LIFECYCLE_KAPT = "android.arch.lifecycle:compiler:${Versions.LIFECYCLE_COMMON}"
+    private const val LIFECYCLE_KAPT = "androidx.lifecycle:lifecycle-compiler:${Versions.LIFECYCLE_COMMON}"
     private const val LIFECYCLE_RUNTIME = "androidx.lifecycle:lifecycle-runtime-ktx:${Versions.LIFECYCLE}"
     private const val LIFECYCLE_LIVEDATA = "androidx.lifecycle:lifecycle-livedata-ktx:${Versions.LIFECYCLE}"
     private const val LIFECYCLE_EXTENSIONS = "androidx.lifecycle:lifecycle-extensions:${Versions.LIFECYCLE_EXTENSIONS}"
@@ -36,7 +35,6 @@ object Dependencies {
         add(CORE_KTX)
         add(APP_COMPAT)
         add(MATERIAL)
-        add(LIFECYCLE_COMMON)
         add(LIFECYCLE_RUNTIME)
     }
 
@@ -46,13 +44,15 @@ object Dependencies {
         add(APP_COMPAT)
         add(MATERIAL)
         add(CONSTRAINT_LAYOUT)
-        add(LIFECYCLE_COMMON)
-        add(LIFECYCLE_KAPT)
         add(LIFECYCLE_RUNTIME)
         add(LIFECYCLE_LIVEDATA)
         add(LIFECYCLE_EXTENSIONS)
         add(LIFECYCLE_VIEW_MODEL)
         add(GUAVA)
+    }
+
+    val appKaptLibraries = arrayListOf<String>().apply {
+        add(LIFECYCLE_KAPT)
     }
 
     val commonTestLibraries = arrayListOf<String>().apply {

--- a/buildSrc/src/main/java/Versions.kt
+++ b/buildSrc/src/main/java/Versions.kt
@@ -13,7 +13,7 @@ object Versions {
     const val CONSTRAINT_LAYOUT = "2.1.3"
     const val COROUTINES_CORE = "1.6.0"
     const val LIFECYCLE = "2.4.0"
-    const val LIFECYCLE_COMMON = "1.1.1"
+    const val LIFECYCLE_COMMON = "2.5.1"
     const val LIFECYCLE_EXTENSIONS = "2.2.0"
     const val GUAVA = "31.1-jre"
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Add FlowForms dependency in your module's build.gradle file :
 <pre><code class="kotlin">
 dependencies {
   ..
-  val flowFormsVersion = "1.3.0"
+  val flowFormsVersion = "1.4.0"
     
   // On KMP projects
   implementation("com.github.rootstrap.FlowForms:FlowForms-Core:$flowFormsVersion")

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,7 +15,6 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 # Android operating system, and which are packaged with your app"s APK
 # https://developer.android.com/topic/libraries/support-library/androidx-rn
 android.useAndroidX=true
-android.enableJetifier=true
 # Kotlin code style for this project: "official" or "obsolete":
 kotlin.code.style=official
 


### PR DESCRIPTION
#### ISSUE[#55]
* closes #55 

---

#### Description
* Changed Field's validation status from MutableStateFlow to a MutableSharedFlow with a replay of 1 and with a buffer drop oldest strategy. This works almost identically to a StateFlow for our purposes, with the difference that this allows the combine function that updates the Field's status to be executed when the fields are re-validated but resulting in the same status.
* Also updated version to 1.4.0 for quick update
* Added a test for this specific behavior. Previous tests are still working
* Updated lifecycle lib, removed old android usages. Updated sourceCompatibility to Java 11 and removed the old Jetifier as it is not needed anymore, improving build speed.
* Fixed an issue happening on the E-mail field in the exampe app UI
