### PR TITLE
Add fieldStatusFlows to retrieve status of form's fields easily

### DIFF
--- a/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
+++ b/FlowForms-Core/src/commonMain/kotlin/com/rootstrap/flowforms/core/form/FlowForm.kt
@@ -84,6 +84,16 @@ class FlowForm internal constructor(
     fun field(id: String) = fields.value[id]
 
     /**
+     * Convenient way to get all the fields' status flows on this form.
+     *
+     * Basically provides a list of [Flow]s where each [Flow] represent one of
+     * this form's field's status.
+     *
+     */
+    val fieldStatusFlows
+        get() = fields.value.values.map { it.status }
+
+    /**
      * Trigger onValueChange validations on the specified [FlowField] (if it exists in this form).
      *
      * For additional information please refer to [DOC_FIELD_VALIDATION_BEHAVIOR]

--- a/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
+++ b/FlowForms-Core/src/commonTest/kotlin/com/rootstrap/flowforms/core/form/FlowFormTest.kt
@@ -69,6 +69,38 @@ class FlowFormTest {
     }
 
     @Test
+    fun `GIVEN a form WHEN created with 3 fields THEN assert fieldStatusFlows gives a flow for each field state`() = runTest {
+        val field1 = mockk<FlowField>()
+        val field2 = mockk<FlowField>()
+        val field3 = mockk<FlowField>()
+
+        every { field1.id } returns FIELD_ID_1
+        every { field1.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_1))
+        every { field2.id } returns FIELD_ID_2
+        every { field2.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_2))
+        every { field3.id } returns FIELD_ID_3
+        every { field3.status } returns flowOf(FieldStatus(fieldId = FIELD_ID_3))
+
+        val fieldIds = mutableListOf(FIELD_ID_1, FIELD_ID_2, FIELD_ID_3)
+        val form = flowForm {
+            fields(field1, field2, field3)
+        }
+
+        form.fieldStatusFlows.also {
+            assertEquals(3, it.size)
+        }.forEach { fieldStatusFlow ->
+            fieldStatusFlow.test {
+                val status = awaitItem()
+
+                assertTrue(fieldIds.remove(status.fieldId))
+                assertEquals(UNMODIFIED, status.code)
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
+        assertTrue(fieldIds.isEmpty())
+    }
+
+    @Test
     fun `GIVEN a form with 2 fields WHEN one field become incorrect THEN assert the form status changes from UNMODIFIED to INCORRECT`()
     = runTest {
         val field1 = mockk<FlowField>()


### PR DESCRIPTION
#### ISSUE[#57]
* closes #57 

---

#### Description
* Added a field to retrieve a list of flows where each flow is one of the form's FieldStatus.
* Before this we needed to do the same everywhere we wanted to listen to the form's field status, leading to duplicate code or unneeded architecture discussions.

---

#### Notes
* This is already being used in a Compose project via a `Snapshot release` on Jitpack

---
